### PR TITLE
decoder: adding out of boundary check while parsing slice header

### DIFF
--- a/decoder/ihevcd_parse_slice_header.c
+++ b/decoder/ihevcd_parse_slice_header.c
@@ -440,6 +440,9 @@ IHEVCD_ERROR_T ihevcd_parse_slice_header(codec_t *ps_codec,
                 {
                     numbits = 32 - CLZ(ps_sps->i1_num_short_term_ref_pic_sets - 1);
                     BITS_PARSE("short_term_ref_pic_set_idx", value, ps_bitstrm, numbits);
+                    if (value >= ps_sps->i1_num_short_term_ref_pic_sets) {
+                        return IHEVCD_INVALID_PARAMETER;
+                    }
                     ps_slice_hdr->i1_short_term_ref_pic_set_idx = value;
                 }
 


### PR DESCRIPTION
Bug: oss-fuzz:17070
Test: hevc_dec_fuzzer

this checks the index of short term reference pic doesnot go beyond the last short term reference pic set 