### PR TITLE
decoder: fix bytes consumed in case slice in header mode error

### DIFF
--- a/decoder/ihevcd_decode.c
+++ b/decoder/ihevcd_decode.c
@@ -792,6 +792,7 @@ WORD32 ihevcd_decode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
         }
         else
         {
+            ps_codec->i4_bytes_remaining -= nal_ofst;
             ret = IHEVCD_SUCCESS;
             break;
         }


### PR DESCRIPTION
Bug: oss-fuzz:23200
Test: hevc_dec_fuzzer