### PR TITLE
Revert "decoder: fix bytes consumed in case slice in header mode error"

### DIFF
--- a/decoder/ihevcd_decode.c
+++ b/decoder/ihevcd_decode.c
@@ -792,7 +792,6 @@ WORD32 ihevcd_decode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
         }
         else
         {
-            ps_codec->i4_bytes_remaining -= nal_ofst;
             ret = IHEVCD_SUCCESS;
             break;
         }


### PR DESCRIPTION
This reverts commit d7b7ccc4cdd21ae22f3f2ae9a362b7704ca4c5e1.

Reason for revert: This breaks decoding using hevcdec binary