### PR TITLE
encoder: Fix warnings due to -WSwitch

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -462,7 +462,6 @@ cc_library_static {
         "-Wall",
         "-Wno-unused-variable",
         "-Wno-unused-parameter",
-        "-Wno-switch",
     ],
 
     export_include_dirs: [

--- a/encoder/hme_interface.h
+++ b/encoder/hme_interface.h
@@ -158,8 +158,7 @@ typedef enum
     ME_MEDIUM_SPEED,
     ME_HIGH_SPEED,
     ME_XTREME_SPEED,
-    ME_XTREME_SPEED_25,
-    ME_USER_DEFINED
+    ME_XTREME_SPEED_25
 } ME_QUALITY_PRESETS_T;
 
 /*****************************************************************************/

--- a/encoder/hme_refine.c
+++ b/encoder/hme_refine.c
@@ -5129,7 +5129,7 @@ void hme_populate_cu_tree(
 
 #if ENABLE_CU_TREE_CULLING
         {
-            cur_ctb_cu_tree_t *ps_32x32_root;
+            cur_ctb_cu_tree_t *ps_32x32_root = NULL;
 
             switch(e_parent_blk_pos)
             {
@@ -5155,6 +5155,11 @@ void hme_populate_cu_tree(
             {
                 ps_32x32_root = ps_ctb_cluster_info->ps_cu_tree_root->ps_child_node_br;
 
+                break;
+            }
+            default:
+            {
+                DBG_PRINTF("Invalid block position %d\n", e_parent_blk_pos);
                 break;
             }
             }
@@ -5249,6 +5254,11 @@ void hme_populate_cu_tree(
 
                 break;
             }
+            default:
+            {
+                DBG_PRINTF("Invalid block position %d\n", e_grandparent_blk_pos);
+                break;
+            }
             }
 
             switch(e_parent_blk_pos)
@@ -5275,6 +5285,11 @@ void hme_populate_cu_tree(
             {
                 ps_16x16_root = ps_32x32_root->ps_child_node_br;
 
+                break;
+            }
+            default:
+            {
+                DBG_PRINTF("Invalid block position %d\n", e_parent_blk_pos);
                 break;
             }
             }

--- a/encoder/ihevce_enc_loop_inter_mode_sifter.c
+++ b/encoder/ihevce_enc_loop_inter_mode_sifter.c
@@ -426,8 +426,8 @@ static WORD8 ihevce_merge_cand_pred_buffer_preparation(
     WORD32 i4_part_wd_pu2;
     WORD32 i4_part_ht_pu2;
     WORD32 i4_buf_offset;
-    UWORD8 *pu1_pred_src;
-    UWORD8 *pu1_pred_dst;
+    UWORD8 *pu1_pred_src = NULL;
+    UWORD8 *pu1_pred_dst = NULL;
     WORD8 i1_retval = pau1_final_pred_buf_id[MERGE_DERIVED][0];
 
     WORD32 i4_stride = i4_pred_stride * u1_num_bytes_per_pel;
@@ -557,6 +557,11 @@ static WORD8 ihevce_merge_cand_pred_buffer_preparation(
 
             break;
         }
+        default:
+        {
+            DBG_PRINTF("Invalid partition type %d\n", u1_part_type);
+            break;
+        }
         }
 
         pf_copy_2d(
@@ -591,7 +596,7 @@ static WORD8 ihevce_mixed_mode_cand_type1_pred_buffer_preparation(
     WORD32 i4_part_ht;
     WORD32 i4_part_wd_pu2;
     WORD32 i4_part_ht_pu2;
-    UWORD8 *pu1_pred_src;
+    UWORD8 *pu1_pred_src = NULL;
     UWORD8 *pu1_pred_dst = NULL;
     WORD8 i1_retval = pau1_final_pred_buf_id[ME_OR_SKIP_DERIVED][0];
 
@@ -667,6 +672,11 @@ static WORD8 ihevce_mixed_mode_cand_type1_pred_buffer_preparation(
 
                 i1_retval = pau1_final_pred_buf_id[ME_OR_SKIP_DERIVED][0];
 
+                break;
+            }
+            default:
+            {
+                DBG_PRINTF("Invalid partition type %d\n", u1_part_type);
                 break;
             }
             }
@@ -910,7 +920,7 @@ static WORD8 ihevce_mixed_mode_cand_type0_pred_buffer_preparation(
     WORD32 i4_part_wd_pu2;
     WORD32 i4_part_ht_pu2;
     WORD32 i4_buf_offset;
-    UWORD8 *pu1_pred_src;
+    UWORD8 *pu1_pred_src = NULL;
     UWORD8 *pu1_pred_dst = NULL;
     WORD8 i1_retval = pau1_final_pred_buf_id[ME_OR_SKIP_DERIVED][0];
 
@@ -979,6 +989,11 @@ static WORD8 ihevce_mixed_mode_cand_type0_pred_buffer_preparation(
 
                 i1_retval = pau1_final_pred_buf_id[MIXED_MODE_TYPE0][0];
 
+                break;
+            }
+            default:
+            {
+                DBG_PRINTF("Invalid partition type %d\n", u1_part_type);
                 break;
             }
             }

--- a/encoder/ihevce_rc_interface.c
+++ b/encoder/ihevce_rc_interface.c
@@ -1785,7 +1785,7 @@ WORD32 ihevce_get_L0_est_satd_based_scd_qp(
 WORD32 ihevce_rc_pre_enc_qp_query(
     void *pv_rc_ctxt, rc_lap_out_params_t *ps_rc_lap_out, WORD32 i4_update_delay)
 {
-    WORD32 scene_type, i4_is_scd = 0, i4_frame_qp, slice_type;
+    WORD32 scene_type, i4_is_scd = 0, i4_frame_qp, slice_type = ISLICE;
     rc_context_t *ps_rc_ctxt = (rc_context_t *)pv_rc_ctxt;
     rc_type_e e_rc_type = ps_rc_ctxt->e_rate_control_type;
     IV_PICTURE_CODING_TYPE_T pic_type = (IV_PICTURE_CODING_TYPE_T)ps_rc_lap_out->i4_rc_pic_type;
@@ -1853,6 +1853,11 @@ WORD32 ihevce_rc_pre_enc_qp_query(
         case IV_B_FRAME:
         {
             slice_type = BSLICE;
+            break;
+        }
+        default:
+        {
+            DBG_PRINTF("Invalid picture type %d\n", pic_type);
             break;
         }
         }
@@ -2086,7 +2091,7 @@ WORD32 ihevce_rc_get_pic_quant(
     WORD32 i4_frame_qp, i4_frame_qp_q6, i4_hevc_frame_qp = -1, i4_deltaQP = 0;
     WORD32 i4_max_frame_bits = (1 << 30);
     rc_type_e e_rc_type = ps_rc_ctxt->e_rate_control_type;
-    WORD32 slice_type, index, i4_num_frames_in_cur_gop, i4_cur_est_texture_bits;
+    WORD32 slice_type = ISLICE, index, i4_num_frames_in_cur_gop, i4_cur_est_texture_bits;
     WORD32 temporal_layer_id = ps_rc_lap_out->i4_rc_temporal_lyr_id;
     IV_PICTURE_CODING_TYPE_T pic_type = (IV_PICTURE_CODING_TYPE_T)ps_rc_lap_out->i4_rc_pic_type;
     picture_type_e rc_pic_type = ihevce_rc_conv_pic_type(
@@ -2138,6 +2143,11 @@ WORD32 ihevce_rc_get_pic_quant(
         case IV_B_FRAME:
         {
             slice_type = BSLICE;
+            break;
+        }
+        default:
+        {
+            DBG_PRINTF("Invalid picture type %d\n", pic_type);
             break;
         }
         }


### PR DESCRIPTION
There were a few switch case blocks that didn't cover all possible cases.
- ME_USER_DEFINED wasn't used anywhere, so removed it.
- In all the other cases fixed, uncovered cases are not reachable, so added a default with a log for those cases.

These above changes require some default initializations.

Bug: 244507923
Test: Builds