### PR TITLE
libhevc: move SEI related code under a macro

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -44,6 +44,7 @@ cc_library_static {
 
         "-O3",
         "-DANDROID",
+        "-DDISABLE_SEI",
         "-Wall",
         "-Werror",
         // common/x86/ihevc_sao_ssse3_intr.c: implicit conversion from
@@ -423,6 +424,7 @@ cc_test {
     host_supported: true,
     cflags: [
         "-DPROFILE_ENABLE",
+        "-DDISABLE_SEI",
         "-DARM",
         "-fPIC",
         "-DMD5_DISABLE",

--- a/decoder/ihevcd_api.c
+++ b/decoder/ihevcd_api.c
@@ -768,6 +768,7 @@ static IV_API_CALL_STATUS_T api_check_struct_sanity(iv_obj_t *ps_handle,
 
                     break;
                 }
+#ifndef DISABLE_SEI
                 case IHEVCD_CXA_CMD_CTL_GET_SEI_MASTERING_PARAMS:
                 {
                     ihevcd_cxa_ctl_get_sei_mastering_params_ip_t *ps_ip;
@@ -796,6 +797,7 @@ static IV_API_CALL_STATUS_T api_check_struct_sanity(iv_obj_t *ps_handle,
 
                     break;
                 }
+#endif
                 case IHEVCD_CXA_CMD_CTL_SET_NUM_CORES:
                 {
                     ihevcd_cxa_ctl_set_num_cores_ip_t *ps_ip;
@@ -3338,6 +3340,7 @@ WORD32 ihevcd_get_vui_params(iv_obj_t *ps_codec_obj,
     return IV_SUCCESS;
 }
 
+#ifndef DISABLE_SEI
 /**
 *******************************************************************************
 *
@@ -3413,6 +3416,7 @@ WORD32 ihevcd_get_sei_mastering_params(iv_obj_t *ps_codec_obj,
 
     return IV_SUCCESS;
 }
+#endif
 
 /**
 *******************************************************************************
@@ -3646,10 +3650,12 @@ WORD32 ihevcd_ctl(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
             ret = ihevcd_get_vui_params(ps_codec_obj, (void *)pv_api_ip,
                                         (void *)pv_api_op);
             break;
+#ifndef DISABLE_SEI
         case IHEVCD_CXA_CMD_CTL_GET_SEI_MASTERING_PARAMS:
             ret = ihevcd_get_sei_mastering_params(ps_codec_obj, (void *)pv_api_ip,
                                         (void *)pv_api_op);
             break;
+#endif
         case IHEVCD_CXA_CMD_CTL_SET_PROCESSOR:
             ret = ihevcd_set_processor(ps_codec_obj, (void *)pv_api_ip,
                             (void *)pv_api_op);

--- a/decoder/ihevcd_cxa.h
+++ b/decoder/ihevcd_cxa.h
@@ -1062,6 +1062,7 @@ typedef struct {
     UWORD8 au1_cpb_cnt_minus1[6];
 }ihevcd_cxa_ctl_get_vui_params_op_t;
 
+#ifndef DISABLE_SEI
 typedef struct
 {
     UWORD32                                     u4_size;
@@ -1105,6 +1106,7 @@ typedef struct
     UWORD32 u4_min_display_mastering_luminance;
 
 }ihevcd_cxa_ctl_get_sei_mastering_params_op_t;
+#endif
 
 #ifdef __cplusplus
 } /* closing brace for extern "C" */

--- a/decoder/ihevcd_decode.c
+++ b/decoder/ihevcd_decode.c
@@ -253,6 +253,7 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
     if(ps_codec->ps_disp_buf)
     {
         pic_buf_t *ps_disp_buf = ps_codec->ps_disp_buf;
+#ifndef DISABLE_SEI
         sei_params_t *ps_sei = &ps_disp_buf->s_sei_params;
 
         if(ps_sei->i1_sei_parameters_present_flag &&
@@ -277,6 +278,7 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
                     break;
             }
         }
+#endif
         ps_dec_op->i4_display_index = ps_disp_buf->i4_abs_poc;
         ps_dec_op->u4_output_present = 1;
         ps_dec_op->u4_ts = ps_disp_buf->u4_ts;

--- a/decoder/ihevcd_error.h
+++ b/decoder/ihevcd_error.h
@@ -123,10 +123,12 @@ typedef enum
      */
     IHEVCD_VUI_PARAMS_NOT_FOUND,
 
+#ifndef DISABLE_SEI
     /**
      * SEI mastering parameters not found
      */
     IHEVCD_SEI_MASTERING_PARAMS_NOT_FOUND,
+#endif
 
 }IHEVCD_ERROR_T;
 #endif /* _IHEVCD_ERROR_H_ */

--- a/decoder/ihevcd_nal.c
+++ b/decoder/ihevcd_nal.c
@@ -451,6 +451,7 @@ IHEVCD_ERROR_T ihevcd_nal_unit(codec_t *ps_codec)
             DEBUG_PRINT_NAL_INFO(ps_codec, s_nal.i1_nal_unit_type);
             break;
 
+#ifndef DISABLE_SEI
         case NAL_PREFIX_SEI:
         case NAL_SUFFIX_SEI:
             if(IVD_DECODE_HEADER == ps_codec->i4_header_mode)
@@ -461,6 +462,7 @@ IHEVCD_ERROR_T ihevcd_nal_unit(codec_t *ps_codec)
             ret = ihevcd_parse_sei(ps_codec, &s_nal);
             break;
 
+#endif
         case NAL_EOS        :
             ps_codec->i4_cra_as_first_pic = 1;
             break;

--- a/decoder/ihevcd_parse_headers.c
+++ b/decoder/ihevcd_parse_headers.c
@@ -2475,6 +2475,7 @@ void ihevcd_copy_pps(codec_t *ps_codec, WORD32 pps_id, WORD32 pps_id_ref)
 }
 
 
+#ifndef DISABLE_SEI
 IHEVCD_ERROR_T ihevcd_parse_buffering_period_sei(codec_t *ps_codec,
                                                  sps_t *ps_sps)
 {
@@ -3185,6 +3186,7 @@ IHEVCD_ERROR_T ihevcd_parse_sei(codec_t *ps_codec, nal_header_t *ps_nal)
 
     return ret;
 }
+#endif
 
 /**
 *******************************************************************************

--- a/decoder/ihevcd_parse_headers.h
+++ b/decoder/ihevcd_parse_headers.h
@@ -42,12 +42,14 @@ void ihevcd_copy_slice_hdr(codec_t *ps_codec, WORD32 slice_idx, WORD32 slice_idx
 IHEVCD_ERROR_T ihevcd_parse_vps(codec_t *ps_codec);
 IHEVCD_ERROR_T ihevcd_parse_sps(codec_t *ps_codec);
 IHEVCD_ERROR_T ihevcd_parse_pps(codec_t *ps_codec);
+#ifndef DISABLE_SEI
 IHEVCD_ERROR_T ihevcd_parse_sei(codec_t *ps_codec, nal_header_t *ps_nal);
 IHEVCD_ERROR_T ihevcd_parse_pic_timing_sei(codec_t *ps_codec, sps_t *ps_sps);
 IHEVCD_ERROR_T ihevcd_parse_buffering_period_sei(codec_t *ps_codec, sps_t *ps_sps);
 IHEVCD_ERROR_T ihevcd_parse_time_code_sei(codec_t *ps_codec);
 IHEVCD_ERROR_T ihevcd_parse_user_data_registered_itu_t_t35(codec_t *ps_codec, UWORD32 u4_payload_size);
 IHEVCD_ERROR_T ihevcd_parse_active_parameter_sets_sei(codec_t *ps_codec, sps_t *ps_sps);
+#endif
 IHEVCD_ERROR_T ihevcd_read_rbsp_trailing_bits(codec_t *ps_codec, UWORD32 u4_bits_left);
 IHEVCD_ERROR_T ihevcd_parse_slice_header(codec_t *ps_codec,
                                          nal_header_t *ps_nal);

--- a/decoder/ihevcd_structs.h
+++ b/decoder/ihevcd_structs.h
@@ -1161,10 +1161,12 @@ typedef struct
      */
     WORD32 i4_next_tu_ctb_cnt;
 
+#ifndef DISABLE_SEI
     /**
      * SEI parameters
      */
     sei_params_t s_sei_params;
+#endif
 }parse_ctxt_t;
 
 /**

--- a/decoder/ihevcd_utils.c
+++ b/decoder/ihevcd_utils.c
@@ -928,6 +928,7 @@ IHEVCD_ERROR_T ihevcd_parse_pic_init(codec_t *ps_codec)
 
         pu1_cur_pic_chroma = pu1_buf;
 
+#ifndef DISABLE_SEI
         ps_cur_pic->s_sei_params.i1_sei_parameters_present_flag = 0;
         if(ps_codec->s_parse.s_sei_params.i1_sei_parameters_present_flag)
         {
@@ -948,6 +949,7 @@ IHEVCD_ERROR_T ihevcd_parse_pic_init(codec_t *ps_codec)
             ps_sei->i1_active_parameter_set = 0;
             ps_sei->i4_sei_mastering_disp_colour_vol_params_present_flags = 0;
         }
+#endif
     }
 
     if(0 == ps_codec->u4_pic_cnt)

--- a/test/decoder/main.c
+++ b/test/decoder/main.c
@@ -3013,6 +3013,7 @@ int main(WORD32 argc, CHAR *argv[])
             /*************************************************************************/
             /* Get SEI mastering display color volume parameters                     */
             /*************************************************************************/
+#ifndef DISABLE_SEI
             if(1 == ps_video_decode_op->u4_output_present)
             {
 
@@ -3038,6 +3039,7 @@ int main(WORD32 argc, CHAR *argv[])
 
             }
 
+#endif
 
             if((1 == s_app_ctx.display) &&
                             (1 == ps_video_decode_op->u4_output_present))


### PR DESCRIPTION
Bug: 338446610
Test: ./hevcdec