### PR TITLE
libhevc: fix disable sei macro in hevc decoder application

### DIFF
--- a/decoder/ihevcd_error.h
+++ b/decoder/ihevcd_error.h
@@ -123,12 +123,10 @@ typedef enum
      */
     IHEVCD_VUI_PARAMS_NOT_FOUND,
 
-#ifndef DISABLE_SEI
     /**
      * SEI mastering parameters not found
      */
     IHEVCD_SEI_MASTERING_PARAMS_NOT_FOUND,
-#endif
 
 }IHEVCD_ERROR_T;
 #endif /* _IHEVCD_ERROR_H_ */


### PR DESCRIPTION
Bug: 338446610
Test: ./hevcdec