### PR TITLE
libhevc: fix encoder SEI related code while disabling SEI

### DIFF
--- a/encoder/ihevce_hle_interface.c
+++ b/encoder/ihevce_hle_interface.c
@@ -521,6 +521,9 @@ IV_API_CALL_STATUS_T ihevce_query_io_buf_req(
 
     ps_input_bufs_req->i4_min_size_asynch_ctrl_bufs =
         ((MAX_SEI_PAYLOAD_PER_TLV + 16) * (MAX_NUMBER_OF_SEI_PAYLOAD - 6)) + 16;
+#else
+    ps_input_bufs_req->i4_min_size_synch_ctrl_bufs = 16;
+    ps_input_bufs_req->i4_min_size_asynch_ctrl_bufs = 16;
 #endif
 
     for(i4_resolution_id_ctr = 0; i4_resolution_id_ctr < i4_num_resolutions; i4_resolution_id_ctr++)


### PR DESCRIPTION
initialise the default size of synchronous and asynchronous command buffers to 16 if sei encoder parsing is disabled

Bug: 338446610
Test: ./hevcenc