### PR TITLE
libhevc: remove unused KEEP_THREADS_ACTIVE flag in Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -50,8 +50,6 @@ cc_library_static {
         // common/x86/ihevc_sao_ssse3_intr.c: implicit conversion from
         // 'int' to 'char' changes value from 128 to -128
         "-Wno-error=constant-conversion",
-        // #KEEP_THREAD_ACTIVE is experimental
-        "-UKEEP_THREADS_ACTIVE",
     ],
 
     export_include_dirs: [


### PR DESCRIPTION
Bug: 376303949
Test: Build and review