### PR TITLE
hevcdec: Updated memory allocation for monochrome

### DIFF
--- a/decoder/ihevcd_ilf_padding.c
+++ b/decoder/ihevcd_ilf_padding.c
@@ -163,30 +163,33 @@ void ihevcd_ilf_pad_frame(deblk_ctxt_t *ps_deblk_ctxt, sao_ctxt_t *ps_sao_ctxt)
                 if(0 == i4_ctb_x)
                 {
                     WORD32 pad_ht_luma;
-                    WORD32 pad_ht_chroma;
 
                     pad_ht_luma = ctb_size;
                     pad_ht_luma += (ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y ? 8 : 0;
-                    pad_ht_chroma = ctb_size / 2;
-                    pad_ht_chroma += (ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y ? 8 : 0;
                     /* Pad left after 1st CTB is processed */
                     ps_codec->s_func_selector.ihevc_pad_left_luma_fptr(pu1_cur_ctb_luma - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_luma, PAD_LEFT);
-                    ps_codec->s_func_selector.ihevc_pad_left_chroma_fptr(pu1_cur_ctb_chroma - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_chroma, PAD_LEFT);
+                    if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+                    {
+                        WORD32 pad_ht_chroma = ctb_size / 2;
+                        pad_ht_chroma += (ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y ? 8 : 0;
+                        ps_codec->s_func_selector.ihevc_pad_left_chroma_fptr(pu1_cur_ctb_chroma - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_chroma, PAD_LEFT);
+                    }
                 }
                 else if((ps_sps->i2_pic_wd_in_ctb - 1) == i4_ctb_x)
                 {
                     WORD32 pad_ht_luma;
-                    WORD32 pad_ht_chroma;
                     WORD32 cols_remaining = ps_sps->i2_pic_width_in_luma_samples - (i4_ctb_x << ps_sps->i1_log2_ctb_size);
 
                     pad_ht_luma = ctb_size;
                     pad_ht_luma += (ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y ? 8 : 0;
-                    pad_ht_chroma = ctb_size / 2;
-                    pad_ht_chroma += (ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y ? 8 : 0;
                     /* Pad right after last CTB in the current row is processed */
                     ps_codec->s_func_selector.ihevc_pad_right_luma_fptr(pu1_cur_ctb_luma + cols_remaining - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_luma, PAD_RIGHT);
-                    ps_codec->s_func_selector.ihevc_pad_right_chroma_fptr(pu1_cur_ctb_chroma + cols_remaining - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_chroma, PAD_RIGHT);
-
+                    if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+                    {
+                        WORD32 pad_ht_chroma = ctb_size / 2;
+                        pad_ht_chroma += (ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y ? 8 : 0;
+                        ps_codec->s_func_selector.ihevc_pad_right_chroma_fptr(pu1_cur_ctb_chroma + cols_remaining - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_chroma, PAD_RIGHT);
+                    }
 
                     if((ps_sps->i2_pic_ht_in_ctb - 1) == i4_ctb_y)
                     {
@@ -195,14 +198,20 @@ void ihevcd_ilf_pad_frame(deblk_ctxt_t *ps_deblk_ctxt, sao_ctxt_t *ps_sao_ctxt)
                         /* Hence moving top padding to to end of frame, Moving it to second row also results in problems when there is only one row */
                         /* Pad top after padding left and right for current rows after processing 1st CTB row */
                         ihevc_pad_top(ps_deblk_ctxt->pu1_cur_pic_luma - PAD_LEFT, ps_codec->i4_strd, ps_sps->i2_pic_width_in_luma_samples + PAD_WD, PAD_TOP);
-                        ihevc_pad_top(ps_deblk_ctxt->pu1_cur_pic_chroma - PAD_LEFT, ps_codec->i4_strd, ps_sps->i2_pic_width_in_luma_samples + PAD_WD, PAD_TOP / 2);
+                        if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+                        {
+                            ihevc_pad_top(ps_deblk_ctxt->pu1_cur_pic_chroma - PAD_LEFT, ps_codec->i4_strd, ps_sps->i2_pic_width_in_luma_samples + PAD_WD, PAD_TOP / 2);
+                        }
 
                         pu1_buf = ps_deblk_ctxt->pu1_cur_pic_luma + ps_codec->i4_strd * ps_sps->i2_pic_height_in_luma_samples - PAD_LEFT;
                         /* Pad top after padding left and right for current rows after processing 1st CTB row */
                         ihevc_pad_bottom(pu1_buf, ps_codec->i4_strd, ps_sps->i2_pic_width_in_luma_samples + PAD_WD, PAD_BOT);
 
-                        pu1_buf = ps_deblk_ctxt->pu1_cur_pic_chroma + ps_codec->i4_strd * (ps_sps->i2_pic_height_in_luma_samples / 2) - PAD_LEFT;
-                        ihevc_pad_bottom(pu1_buf, ps_codec->i4_strd, ps_sps->i2_pic_width_in_luma_samples + PAD_WD, PAD_BOT / 2);
+                        if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+                        {
+                            pu1_buf = ps_deblk_ctxt->pu1_cur_pic_chroma + ps_codec->i4_strd * (ps_sps->i2_pic_height_in_luma_samples / 2) - PAD_LEFT;
+                            ihevc_pad_bottom(pu1_buf, ps_codec->i4_strd, ps_sps->i2_pic_width_in_luma_samples + PAD_WD, PAD_BOT / 2);
+                        }
                     }
                 }
             }

--- a/decoder/ihevcd_inter_pred.c
+++ b/decoder/ihevcd_inter_pred.c
@@ -163,6 +163,7 @@ void ihevcd_inter_pred_ctb(process_ctxt_t *ps_proc)
     WORD32 next_ctb_idx;
     WORD8(*coeff)[8];
     WORD32  chroma_yuv420sp_vu;
+    WORD32 num_comp;
 
     PROFILE_DISABLE_INTER_PRED();
     ps_codec = ps_proc->ps_codec;
@@ -211,6 +212,8 @@ void ihevcd_inter_pred_ctb(process_ctxt_t *ps_proc)
     chroma_offset_l1_cb = 0;
     chroma_offset_l1_cr = 0;
 
+    num_comp = ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_MONOCHROME ? 1 : 2;
+
     for(pu_indx = 0; pu_indx < i4_pu_cnt; pu_indx++, ps_pu++)
     {
         /* If the PU is intra then proceed to the next */
@@ -233,15 +236,20 @@ void ihevcd_inter_pred_ctb(process_ctxt_t *ps_proc)
             ps_pic_buf_l0 = (pic_buf_t *)((ps_slice_hdr->as_ref_pic_list0[ps_pu->mv.i1_l0_ref_idx].pv_pic_buf));
 
             ref_pic_luma_l0 = ps_pic_buf_l0->pu1_luma;
-            ref_pic_chroma_l0 = ps_pic_buf_l0->pu1_chroma;
 
             luma_weight_l0 = ps_slice_hdr->s_wt_ofst.i2_luma_weight_l0[ps_pu->mv.i1_l0_ref_idx];
-            chroma_weight_l0_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l0_cb[ps_pu->mv.i1_l0_ref_idx];
-            chroma_weight_l0_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l0_cr[ps_pu->mv.i1_l0_ref_idx];
 
             luma_offset_l0 = ps_slice_hdr->s_wt_ofst.i2_luma_offset_l0[ps_pu->mv.i1_l0_ref_idx];
-            chroma_offset_l0_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l0_cb[ps_pu->mv.i1_l0_ref_idx];
-            chroma_offset_l0_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l0_cr[ps_pu->mv.i1_l0_ref_idx];
+
+            if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+            {
+                ref_pic_chroma_l0 = ps_pic_buf_l0->pu1_chroma;
+                chroma_weight_l0_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l0_cb[ps_pu->mv.i1_l0_ref_idx];
+                chroma_weight_l0_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l0_cr[ps_pu->mv.i1_l0_ref_idx];
+
+                chroma_offset_l0_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l0_cb[ps_pu->mv.i1_l0_ref_idx];
+                chroma_offset_l0_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l0_cr[ps_pu->mv.i1_l0_ref_idx];
+            }
         }
 
         if(ps_pu->b2_pred_mode != PRED_L0)
@@ -249,19 +257,24 @@ void ihevcd_inter_pred_ctb(process_ctxt_t *ps_proc)
             pic_buf_t *ps_pic_buf_l1;
             ps_pic_buf_l1 = (pic_buf_t *)((ps_slice_hdr->as_ref_pic_list1[ps_pu->mv.i1_l1_ref_idx].pv_pic_buf));
             ref_pic_luma_l1 = ps_pic_buf_l1->pu1_luma;
-            ref_pic_chroma_l1 = ps_pic_buf_l1->pu1_chroma;
 
             luma_weight_l1 = ps_slice_hdr->s_wt_ofst.i2_luma_weight_l1[ps_pu->mv.i1_l1_ref_idx];
-            chroma_weight_l1_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l1_cb[ps_pu->mv.i1_l1_ref_idx];
-            chroma_weight_l1_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l1_cr[ps_pu->mv.i1_l1_ref_idx];
 
             luma_offset_l1 = ps_slice_hdr->s_wt_ofst.i2_luma_offset_l1[ps_pu->mv.i1_l1_ref_idx];
-            chroma_offset_l1_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l1_cb[ps_pu->mv.i1_l1_ref_idx];
-            chroma_offset_l1_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l1_cr[ps_pu->mv.i1_l1_ref_idx];
+
+            if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+            {
+                ref_pic_chroma_l1 = ps_pic_buf_l1->pu1_chroma;
+                chroma_weight_l1_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l1_cb[ps_pu->mv.i1_l1_ref_idx];
+                chroma_weight_l1_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_weight_l1_cr[ps_pu->mv.i1_l1_ref_idx];
+
+                chroma_offset_l1_cb = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l1_cb[ps_pu->mv.i1_l1_ref_idx];
+                chroma_offset_l1_cr = ps_slice_hdr->s_wt_ofst.i2_chroma_offset_l1_cr[ps_pu->mv.i1_l1_ref_idx];
+            }
         }
 
         /*luma and chroma components*/
-        for(clr_indx = 0; clr_indx < 2; clr_indx++)
+        for(clr_indx = 0; clr_indx < num_comp; clr_indx++)
         {
             PROFILE_DISABLE_INTER_PRED_LUMA(clr_indx);
             PROFILE_DISABLE_INTER_PRED_CHROMA(clr_indx);

--- a/decoder/ihevcd_iquant_itrans_recon_ctb.c
+++ b/decoder/ihevcd_iquant_itrans_recon_ctb.c
@@ -734,7 +734,6 @@ WORD32 ihevcd_iquant_itrans_recon_ctb(process_ctxt_t *ps_proc)
 
             tu_y_offset = tu_x + tu_y * pic_strd;
             pu1_y_dst += tu_x + tu_y * pic_strd;
-            pu1_uv_dst += tu_x + (tu_y >> 1) * pic_strd;
 
             /* First byte points to number of coded blocks */
             pu1_tu_coeff_data++;
@@ -754,25 +753,29 @@ WORD32 ihevcd_iquant_itrans_recon_ctb(process_ctxt_t *ps_proc)
                     pu1_buf += cb_size;
                 }
 
-                pu1_uv_dst = pu1_uv_dst + chroma_yuv420sp_vu_u_offset;
-
-                /* U */
-                for(i = 0; i < cb_size / 2; i++)
+                if(ps_sps->i1_chroma_format_idc != CHROMA_FMT_IDC_MONOCHROME)
                 {
-                    for(j = 0; j < cb_size / 2; j++)
+                    pu1_uv_dst += tu_x + (tu_y >> 1) * pic_strd;
+                    pu1_uv_dst = pu1_uv_dst + chroma_yuv420sp_vu_u_offset;
+
+                    /* U */
+                    for(i = 0; i < cb_size / 2; i++)
                     {
-                        pu1_uv_dst[i * pic_strd + 2 * j] = *pu1_buf++;
+                        for(j = 0; j < cb_size / 2; j++)
+                        {
+                            pu1_uv_dst[i * pic_strd + 2 * j] = *pu1_buf++;
+                        }
                     }
-                }
 
-                pu1_uv_dst = pu1_uv_dst + 1 + chroma_yuv420sp_vu_v_offset;
+                    pu1_uv_dst = pu1_uv_dst + 1 + chroma_yuv420sp_vu_v_offset;
 
-                /* V */
-                for(i = 0; i < cb_size / 2; i++)
-                {
-                    for(j = 0; j < cb_size / 2; j++)
+                    /* V */
+                    for(i = 0; i < cb_size / 2; i++)
                     {
-                        pu1_uv_dst[i * pic_strd + 2 * j] = *pu1_buf++;
+                        for(j = 0; j < cb_size / 2; j++)
+                        {
+                            pu1_uv_dst[i * pic_strd + 2 * j] = *pu1_buf++;
+                        }
                     }
                 }
             }

--- a/decoder/ihevcd_process_slice.c
+++ b/decoder/ihevcd_process_slice.c
@@ -974,9 +974,12 @@ IHEVCD_ERROR_T ihevcd_process(process_ctxt_t *ps_proc)
                                 + (ps_proc->i4_ctb_x * ctb_size
                                 + ps_proc->i4_ctb_y * ctb_size
                                 * ps_codec->i4_strd);
-                ps_proc->pu1_cur_ctb_chroma = ps_proc->pu1_cur_pic_chroma
-                                + ps_proc->i4_ctb_x * ctb_size
-                                + (ps_proc->i4_ctb_y * ctb_size * ps_codec->i4_strd / 2);
+                if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+                {
+                    ps_proc->pu1_cur_ctb_chroma = ps_proc->pu1_cur_pic_chroma
+                                    + ps_proc->i4_ctb_x * ctb_size
+                                    + (ps_proc->i4_ctb_y * ctb_size * ps_codec->i4_strd / 2);
+                }
 
                 ihevcd_iquant_itrans_recon_ctb(ps_proc);
             }
@@ -1212,17 +1215,17 @@ IHEVCD_ERROR_T ihevcd_process(process_ctxt_t *ps_proc)
                                         + (ps_proc->i4_ctb_x * ctb_size
                                         + ps_proc->i4_ctb_y * ctb_size
                                         * ps_codec->i4_strd);
-                        ps_proc->pu1_cur_ctb_chroma = ps_proc->pu1_cur_pic_chroma
-                                        + ps_proc->i4_ctb_x * ctb_size
-                                        + (ps_proc->i4_ctb_y * ctb_size * ps_codec->i4_strd / 2);
 
                         pad_ht_luma = ctb_size;
                         pad_ht_luma += (ps_sps->i2_pic_ht_in_ctb - 1) == ps_proc->i4_ctb_y ? 8 : 0;
-                        pad_ht_chroma = ctb_size / 2;
                         /* Pad left after 1st CTB is processed */
                         ps_codec->s_func_selector.ihevc_pad_left_luma_fptr(ps_proc->pu1_cur_ctb_luma - 8 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_luma, PAD_LEFT);
                         if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
                         {
+                            ps_proc->pu1_cur_ctb_chroma = ps_proc->pu1_cur_pic_chroma
+                                            + ps_proc->i4_ctb_x * ctb_size
+                                            + (ps_proc->i4_ctb_y * ctb_size * ps_codec->i4_strd / 2);
+                            pad_ht_chroma = ctb_size / 2;
                             ps_codec->s_func_selector.ihevc_pad_left_chroma_fptr(ps_proc->pu1_cur_ctb_chroma - 16 * ps_codec->i4_strd, ps_codec->i4_strd, pad_ht_chroma, PAD_LEFT);
                         }
                     }
@@ -1237,12 +1240,14 @@ IHEVCD_ERROR_T ihevcd_process(process_ctxt_t *ps_proc)
                                         + (ps_proc->i4_ctb_x * ctb_size
                                         + ps_proc->i4_ctb_y * ctb_size
                                         * ps_codec->i4_strd);
-                        ps_proc->pu1_cur_ctb_chroma = ps_proc->pu1_cur_pic_chroma
-                                        + ps_proc->i4_ctb_x * ctb_size
-                                        + (ps_proc->i4_ctb_y * ctb_size * ps_codec->i4_strd / 2);
-
+                        if (CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+                        {
+                            ps_proc->pu1_cur_ctb_chroma = ps_proc->pu1_cur_pic_chroma
+                                            + ps_proc->i4_ctb_x * ctb_size
+                                            + (ps_proc->i4_ctb_y * ctb_size * ps_codec->i4_strd / 2);
+                            pad_ht_chroma = ctb_size / 2;
+                        }
                         pad_ht_luma = ctb_size;
-                        pad_ht_chroma = ctb_size / 2;
                         if((ps_sps->i2_pic_ht_in_ctb - 1) == ps_proc->i4_ctb_y)
                         {
                             pad_ht_luma += 8;

--- a/decoder/ihevcd_sao.c
+++ b/decoder/ihevcd_sao.c
@@ -364,6 +364,9 @@ void ihevcd_sao_ctb(sao_ctxt_t *ps_sao_ctxt)
 
         }
 
+        /* Chroma */
+        if(CHROMA_FMT_IDC_MONOCHROME != ps_sps->i1_chroma_format_idc)
+        {
         if(0 == ps_sao->b3_cb_type_idx)
         {
             for(row = 0; row < sao_ht_chroma; row++)
@@ -517,7 +520,7 @@ void ihevcd_sao_ctb(sao_ctxt_t *ps_sao_ctxt)
             }
 
         }
-
+        }
     }
 }
 

--- a/decoder/ihevcd_utils.h
+++ b/decoder/ihevcd_utils.h
@@ -40,7 +40,7 @@
 WORD32 ihevcd_get_lvl_idx(WORD32 level);
 WORD32 ihevcd_get_dpb_size(WORD32 level, WORD32 pic_size);
 WORD32 ihevcd_get_pic_mv_bank_size(WORD32 num_luma_samples);
-WORD32 ihevcd_get_tu_data_size(WORD32 num_luma_samples);
+WORD32 ihevcd_get_tu_data_size(codec_t *ps_codec, WORD32 num_luma_samples);
 WORD32 ihevcd_nctb_cnt(codec_t *ps_codec, sps_t *ps_sps);
 WORD32 ihevcd_get_max_luma_samples(WORD32 level);
 IHEVCD_ERROR_T ihevcd_get_tile_pos(pps_t *ps_pps,


### PR DESCRIPTION
Updated library to allocate memory only for luma in case of monochrome profile.

Bug:
Test: ./hevcdec

Change-Id: I5649bbd94e10d2c19fa7548b2380db598c9ff2b6