### PR TITLE
libhevc: added BTI and PAC support in libhevc

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -35,7 +35,6 @@ cc_library_headers {
 
 cc_library_static {
     name: "libhevcdec",
-    defaults: ["no_bti"],
     vendor_available: true,
     host_supported: true,
 
@@ -441,7 +440,6 @@ cc_binary {
 
 cc_library_static {
     name: "libhevcenc",
-    defaults: ["no_bti"],
     vendor_available: true,
     host_supported: true,
     cflags: [

--- a/common/arm64/ihevc_deblk_chroma_horz.s
+++ b/common/arm64/ihevc_deblk_chroma_horz.s
@@ -45,9 +45,8 @@
 //                             WORD32 filter_flag_q)
 //
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -57,7 +56,7 @@
 
 .type ihevc_deblk_chroma_horz_av8, %function
 
-ihevc_deblk_chroma_horz_av8:
+ENTRY ihevc_deblk_chroma_horz_av8
     sxtw        x4,w4
     sxtw        x5,w5
     sxtw        x6,w6
@@ -166,6 +165,7 @@ l1.3528:
 l1.3540:
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_deblk_chroma_vert.s
+++ b/common/arm64/ihevc_deblk_chroma_vert.s
@@ -46,9 +46,8 @@
 //                             WORD32 filter_flag_p,
 //                             WORD32 filter_flag_q)
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -58,7 +57,7 @@
 
 .type ihevc_deblk_chroma_vert_av8, %function
 
-ihevc_deblk_chroma_vert_av8:
+ENTRY ihevc_deblk_chroma_vert_av8
     sxtw        x4,w4
     sxtw        x5,w5
     sxtw        x6,w6
@@ -205,6 +204,7 @@ l1.3204:
 l1.3228:
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_deblk_luma_horz.s
+++ b/common/arm64/ihevc_deblk_luma_horz.s
@@ -36,8 +36,8 @@
 //*
 //*******************************************************************************/
 
+.include "ihevc_neon_macros.s"
 .text
-.align 4
 
 
 .extern gai4_ihevc_tc_table
@@ -46,7 +46,7 @@
 
 .type ihevc_deblk_luma_horz_av8, %function
 
-ihevc_deblk_luma_horz_av8:
+ENTRY ihevc_deblk_luma_horz_av8
     // stmfd sp!, {x3-x12,x14}
     sxtw        x5,w5
     sxtw        x6,w6
@@ -434,6 +434,7 @@ l1.2404:
     ldp         d10,d11,[sp],#16
     ldp         d8,d9,[sp],#16              // Loading d9 using { ldr d9,[sp]; add sp,sp,#8 } is giving bus error.
                                             // d8 is used as dummy register and loaded along with d9 using ldp. d8 is not used in the function.
+    EXIT_FUNC
     ret
 
     // x4=flag p
@@ -584,6 +585,7 @@ l1.2852:
     ldp         d10,d11,[sp],#16
     ldp         d8,d9,[sp],#16              // Loading d9 using { ldr d9,[sp]; add sp,sp,#8 } is giving bus error.
                                             // d8 is used as dummy register and loaded along with d9 using ldp. d8 is not used in the function.
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_deblk_luma_vert.s
+++ b/common/arm64/ihevc_deblk_luma_vert.s
@@ -37,8 +37,8 @@
 //*
 //*******************************************************************************/
 
+.include "ihevc_neon_macros.s"
 .text
-.align 4
 
 
 
@@ -49,7 +49,7 @@
 
 .type ihevc_deblk_luma_vert_av8, %function
 
-ihevc_deblk_luma_vert_av8:
+ENTRY ihevc_deblk_luma_vert_av8
 
     sxtw        x5,w5
     sxtw        x6,w6
@@ -450,6 +450,7 @@ l1.964:
     ldp         d12,d13,[sp],#16
     ldp         d10,d11,[sp],#16
     ldp         d8,d9,[sp],#16
+    EXIT_FUNC
     ret
 
 l1.968:
@@ -630,6 +631,7 @@ l1.1412:
     ldp         d12,d13,[sp],#16
     ldp         d10,d11,[sp],#16
     ldp         d8,d9,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_copy.s
+++ b/common/arm64/ihevc_inter_pred_chroma_copy.s
@@ -91,14 +91,14 @@
 //x5 =>  ht
 //x6 =>  wd
 
+.include "ihevc_neon_macros.s"
 .text
-.align 4
 
 .globl ihevc_inter_pred_chroma_copy_av8
 
 .type ihevc_inter_pred_chroma_copy_av8, %function
 
-ihevc_inter_pred_chroma_copy_av8:
+ENTRY ihevc_inter_pred_chroma_copy_av8
 
     LSL         x12,x6,#1                   //wd << 1
     CMP         x5,#0                       //checks ht == 0
@@ -142,7 +142,8 @@ END_INNER_LOOP_WD_4:
     BGT         OUTER_LOOP_WD_4_HT_2
 
 END_LOOPS:
-    RET
+    EXIT_FUNC
+    ret
 
 OUTER_LOOP_WD_4_HT_2:
     SUBS        x4,x12,#0                   //checks wd == 0
@@ -251,6 +252,7 @@ INNER_LOOP_WD_16_HT_2:
     LD1         {v1.16b},[x7],x2            //vld1_u8(pu1_src_tmp)
     ST1         {v1.16b},[x6],x3            //vst1_u8(pu1_dst_tmp, tmp_src)
 
-    RET
+    EXIT_FUNC
+    ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_copy_w16out.s
+++ b/common/arm64/ihevc_inter_pred_chroma_copy_w16out.s
@@ -92,16 +92,14 @@
 //x5 =>  ht
 //x6 =>  wd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_copy_w16out_av8
 
 .type ihevc_inter_pred_chroma_copy_w16out_av8, %function
 
-ihevc_inter_pred_chroma_copy_w16out_av8:
+ENTRY ihevc_inter_pred_chroma_copy_w16out_av8
 
     // stmfd sp!, {x4-x12, x14}        //stack stores the values of the arguments
 
@@ -173,6 +171,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}        //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 
@@ -339,6 +338,7 @@ core_loop_wd_8_ht_2:
     // ldmfd sp!,{x4-x12,x15}         //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_horz.s
+++ b/common/arm64/ihevc_inter_pred_chroma_horz.s
@@ -93,16 +93,15 @@
 //x2 =>  src_strd
 //x3 =>  dst_strd
 
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_horz_av8
 
 .type ihevc_inter_pred_chroma_horz_av8, %function
 
-ihevc_inter_pred_chroma_horz_av8:
+ENTRY ihevc_inter_pred_chroma_horz_av8
 
     // stmfd sp!, {x4-x12, x14}                    //stack stores the values of the arguments
 
@@ -769,6 +768,7 @@ end_loops:
     ldp         d13,d14,[sp],#16
     ldp         d11,d12,[sp],#16
     ldp         d9,d10,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_horz_w16out.s
+++ b/common/arm64/ihevc_inter_pred_chroma_horz_w16out.s
@@ -91,17 +91,16 @@
 //x3 =>  dst_strd
 
 
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_horz_w16out_av8
 
 
 .type ihevc_inter_pred_chroma_horz_w16out_av8, %function
 
-ihevc_inter_pred_chroma_horz_w16out_av8:
+ENTRY ihevc_inter_pred_chroma_horz_w16out_av8
 
     // stmfd sp!, {x4-x12, x14}                    //stack stores the values of the arguments
 
@@ -794,6 +793,7 @@ end_loops:
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
     ldp         d10,d11,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_vert.s
+++ b/common/arm64/ihevc_inter_pred_chroma_vert.s
@@ -92,16 +92,15 @@
 //x1 => *pi2_dst
 //x2 =>  src_strd
 //x3 =>  dst_strd
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_vert_av8
 
 .type ihevc_inter_pred_chroma_vert_av8, %function
 
-ihevc_inter_pred_chroma_vert_av8:
+ENTRY ihevc_inter_pred_chroma_vert_av8
 
     // stmfd sp!,{x4-x12,x14}        //stack stores the values of the arguments
 
@@ -399,6 +398,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}        //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_vert_w16inp.s
+++ b/common/arm64/ihevc_inter_pred_chroma_vert_w16inp.s
@@ -92,16 +92,14 @@
 //x2 =>  src_strd
 //x3 =>  dst_strd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_vert_w16inp_av8
 
 .type ihevc_inter_pred_chroma_vert_w16inp_av8, %function
 
-ihevc_inter_pred_chroma_vert_w16inp_av8:
+ENTRY ihevc_inter_pred_chroma_vert_w16inp_av8
 
     // stmfd sp!, {x4-x12, x14}                    //stack stores the values of the arguments
 
@@ -349,6 +347,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_vert_w16inp_w16out.s
+++ b/common/arm64/ihevc_inter_pred_chroma_vert_w16inp_w16out.s
@@ -92,16 +92,15 @@
 //x1 => *pi2_dst
 //x2 =>  src_strd
 //x3 =>  dst_strd
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_vert_w16inp_w16out_av8
 
 .type ihevc_inter_pred_chroma_vert_w16inp_w16out_av8, %function
 
-ihevc_inter_pred_chroma_vert_w16inp_w16out_av8:
+ENTRY ihevc_inter_pred_chroma_vert_w16inp_w16out_av8
 
     // stmfd sp!, {x4-x12, x14}                    //stack stores the values of the arguments
 
@@ -336,6 +335,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_chroma_vert_w16out.s
+++ b/common/arm64/ihevc_inter_pred_chroma_vert_w16out.s
@@ -93,16 +93,14 @@
 //x2 =>  src_strd
 //x3 =>  dst_strd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_chroma_vert_w16out_av8
 
 .type ihevc_inter_pred_chroma_vert_w16out_av8, %function
 
-ihevc_inter_pred_chroma_vert_w16out_av8:
+ENTRY ihevc_inter_pred_chroma_vert_w16out_av8
 
     // stmfd sp!,{x4-x12,x14}        //stack stores the values of the arguments
 
@@ -386,6 +384,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_filters_luma_horz.s
+++ b/common/arm64/ihevc_inter_pred_filters_luma_horz.s
@@ -103,16 +103,15 @@
 //    x5 =>  ht
 //    x6 =>  wd
 
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_horz_av8
 
 .type ihevc_inter_pred_luma_horz_av8, %function
 
-ihevc_inter_pred_luma_horz_av8:
+ENTRY ihevc_inter_pred_luma_horz_av8
 
     // stmfd sp!, {x4-x12, x14}                //stack stores the values of the arguments
     push_v_regs
@@ -286,6 +285,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -481,6 +481,7 @@ end_loops1:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -595,6 +596,7 @@ end_inner_loop_4:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_filters_luma_vert.s
+++ b/common/arm64/ihevc_inter_pred_filters_luma_vert.s
@@ -103,16 +103,15 @@
 //    x12 => *pi1_coeff
 //    x5 =>  ht
 //    x3 =>  wd
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_vert_av8
 
 .type ihevc_inter_pred_luma_vert_av8, %function
 
-ihevc_inter_pred_luma_vert_av8:
+ENTRY ihevc_inter_pred_luma_vert_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
 
@@ -428,6 +427,7 @@ end_loops:
     bne         lbl409
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 lbl409:
     mov         x5, #4
@@ -518,5 +518,6 @@ end_inner_loop_wd_4:
     // ldmfd sp!, {x4-x12, x15}    //reload the registers from sp
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 

--- a/common/arm64/ihevc_inter_pred_filters_luma_vert_w16inp.s
+++ b/common/arm64/ihevc_inter_pred_filters_luma_vert_w16inp.s
@@ -94,16 +94,15 @@
 //                                    word32 ht,
 //                                    word32 wd   )
 
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_vert_w16inp_av8
 
 .type ihevc_inter_pred_luma_vert_w16inp_av8, %function
 
-ihevc_inter_pred_luma_vert_w16inp_av8:
+ENTRY ihevc_inter_pred_luma_vert_w16inp_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
 
@@ -384,6 +383,7 @@ end_loops:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_filters_luma_vert_w16out.s
+++ b/common/arm64/ihevc_inter_pred_filters_luma_vert_w16out.s
@@ -62,12 +62,13 @@
 
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_vert_w16out_av8
 
 .type ihevc_inter_pred_luma_vert_w16out_av8, %function
 
-ihevc_inter_pred_luma_vert_w16out_av8:
+ENTRY ihevc_inter_pred_luma_vert_w16out_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
 
@@ -378,6 +379,7 @@ end_loops_16out:
     bne         lbl355
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 lbl355:
     mov         x5, #4
@@ -471,6 +473,7 @@ end_inner_loop_wd_4_16out:
     // ldmfd sp!, {x4-x12, x15}    //reload the registers from sp
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_luma_copy.s
+++ b/common/arm64/ihevc_inter_pred_luma_copy.s
@@ -71,16 +71,14 @@
 //    x11 =>  ht
 //    x16 => wd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_copy_av8
 
 .type ihevc_inter_pred_luma_copy_av8, %function
 
-ihevc_inter_pred_luma_copy_av8:
+ENTRY ihevc_inter_pred_luma_copy_av8
     // stmfd sp!, {x8-x16, lr}                //stack stores the values of the arguments
     stp         x19,x20,[sp, #-16]!
     mov         x16,x6                      //loads wd
@@ -125,6 +123,7 @@ end_loops:
 //  MRS x20,PMCCFILTR_EL0
     sub         x0,x20,x19
     ldp         x19,x20,[sp],#16
+    EXIT_FUNC
     ret
 
 
@@ -159,6 +158,7 @@ end_inner_loop_wd_8:
 //  MRS x20,PMCCFILTR_EL0
     sub         x0,x20,x19
     ldp         x19,x20,[sp],#16
+    EXIT_FUNC
     ret
 
 core_loop_wd_16:
@@ -192,6 +192,7 @@ end_inner_loop_wd_16:
 //  MRS x20,PMCCFILTR_EL0
     sub         x0,x20,x19
     ldp         x19,x20,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_luma_copy_w16out.s
+++ b/common/arm64/ihevc_inter_pred_luma_copy_w16out.s
@@ -72,16 +72,15 @@
 //    x7 =>  ht
 //    x12 => wd
 
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_copy_w16out_av8
 
 .type ihevc_inter_pred_luma_copy_w16out_av8, %function
 
-ihevc_inter_pred_luma_copy_w16out_av8:
+ENTRY ihevc_inter_pred_luma_copy_w16out_av8
 
     // stmfd sp!, {x4-x12, x14}        //stack stores the values of the arguments
 
@@ -140,6 +139,7 @@ end_loops:
     ldp         x19, x20,[sp], #16
 
 
+    EXIT_FUNC
     ret
 
 
@@ -265,6 +265,7 @@ epilog_end:
     // ldmfd sp!,{x4-x12,x15}        //reload the registers from sp
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_luma_horz_w16out.s
+++ b/common/arm64/ihevc_inter_pred_luma_horz_w16out.s
@@ -107,16 +107,15 @@
 //x15 - #1
 //x16 - src_ptx1
 //x19 - loop_counter
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_horz_w16out_av8
 
 .type ihevc_inter_pred_luma_horz_w16out_av8, %function
 
-ihevc_inter_pred_luma_horz_w16out_av8:
+ENTRY ihevc_inter_pred_luma_horz_w16out_av8
 
     // stmfd sp!, {x8-x16, x19}                //stack stores the values of the arguments
     push_v_regs
@@ -305,6 +304,7 @@ height_residue_4:
     bne         lbl280
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 lbl280:
 
@@ -365,6 +365,7 @@ end_inner_loop_height_residue_4:
     // ldmfd sp!,{x8-x16,pc}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 outer_loop8_residual:
@@ -476,6 +477,7 @@ end_inner_loop_8:
     // ldmfd sp!,{x8-x16,pc}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -666,6 +668,7 @@ end_loops1:
     // ldmfd sp!,{x8-x16,pc}                  //reload the registers from sp
     ldp         x19, x20,[sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_inter_pred_luma_vert_w16inp_w16out.s
+++ b/common/arm64/ihevc_inter_pred_luma_vert_w16inp_w16out.s
@@ -102,16 +102,14 @@
 //  r5 =>  ht
 //  r6 =>  wd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_inter_pred_luma_vert_w16inp_w16out_av8
 
 .type ihevc_inter_pred_luma_vert_w16inp_w16out_av8, %function
 
-ihevc_inter_pred_luma_vert_w16inp_w16out_av8:
+ENTRY ihevc_inter_pred_luma_vert_w16inp_w16out_av8
 
     //stmfd     sp!, {r4-r12, r14}  //stack stores the values of the arguments
 
@@ -408,6 +406,7 @@ end_loops:
     //ldmfd     sp!,{r4-r12,r15}            //reload the registers from sp
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_dc.s
+++ b/common/arm64/ihevc_intra_pred_chroma_dc.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_chroma_dc_av8, %function
 
-ihevc_intra_pred_chroma_dc_av8:
+ENTRY ihevc_intra_pred_chroma_dc_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
     push_v_regs
@@ -293,6 +292,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}     //reload the registers from sp
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_horz.s
+++ b/common/arm64/ihevc_intra_pred_chroma_horz.s
@@ -84,16 +84,15 @@
 //x2 => *pu1_dst
 //x3 =>  dst_strd
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevc_intra_pred_chroma_horz_av8
 
 .type ihevc_intra_pred_chroma_horz_av8, %function
 
-ihevc_intra_pred_chroma_horz_av8:
+ENTRY ihevc_intra_pred_chroma_horz_av8
 
     // stmfd sp!, {x4-x12, x14}                //stack stores the values of the arguments
 
@@ -189,6 +188,7 @@ core_loop_16:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
     b           endloop
 
@@ -270,6 +270,7 @@ core_loop_8:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
     b           endloop
 
@@ -318,6 +319,7 @@ core_loop_4:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
     b           endloop
 
@@ -353,6 +355,7 @@ core_loop_4:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 endloop:

--- a/common/arm64/ihevc_intra_pred_chroma_mode2.s
+++ b/common/arm64/ihevc_intra_pred_chroma_mode2.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_chroma_mode2_av8, %function
 
-ihevc_intra_pred_chroma_mode2_av8:
+ENTRY ihevc_intra_pred_chroma_mode2_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
     push_v_regs
@@ -303,6 +302,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_mode_18_34.s
+++ b/common/arm64/ihevc_intra_pred_chroma_mode_18_34.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_chroma_mode_18_34_av8, %function
 
-ihevc_intra_pred_chroma_mode_18_34_av8:
+ENTRY ihevc_intra_pred_chroma_mode_18_34_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
 
@@ -189,6 +188,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_mode_27_to_33.s
+++ b/common/arm64/ihevc_intra_pred_chroma_mode_27_to_33.s
@@ -81,9 +81,8 @@
 //                                         word32 nt,
 //                                         word32 mode)
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevc_intra_pred_chroma_mode_27_to_33_av8
@@ -92,7 +91,7 @@
 
 .type ihevc_intra_pred_chroma_mode_27_to_33_av8, %function
 
-ihevc_intra_pred_chroma_mode_27_to_33_av8:
+ENTRY ihevc_intra_pred_chroma_mode_27_to_33_av8
 
     // stmfd sp!, {x4-x12, x14}                //stack stores the values of the arguments
 
@@ -549,6 +548,7 @@ end_loops:
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
     ldp         d9,d10,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_mode_3_to_9.s
+++ b/common/arm64/ihevc_intra_pred_chroma_mode_3_to_9.s
@@ -86,10 +86,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -101,7 +99,7 @@
 
 .type ihevc_intra_pred_chroma_mode_3_to_9_av8, %function
 
-ihevc_intra_pred_chroma_mode_3_to_9_av8:
+ENTRY ihevc_intra_pred_chroma_mode_3_to_9_av8
 
     // stmfd sp!, {x4-x12, x14}        //stack stores the values of the arguments
 
@@ -489,6 +487,7 @@ end_func:
     ldp         d8,d15,[sp],#16             // Loading d15 using { ldr d15,[sp]; add sp,sp,#8 } is giving bus error.
                                             // d8 is used as dummy register and loaded along with d15 using ldp. d8 is not used in the function.
     ldp         d13,d14,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_planar.s
+++ b/common/arm64/ihevc_intra_pred_chroma_planar.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevc_intra_pred_chroma_planar_av8
@@ -103,7 +102,7 @@
 
 .type ihevc_intra_pred_chroma_planar_av8, %function
 
-ihevc_intra_pred_chroma_planar_av8:
+ENTRY ihevc_intra_pred_chroma_planar_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -374,6 +373,7 @@ end_loop:
                                             // d8 is used as dummy register and loaded along with d14 using ldp. d8 is not used in the function.
     ldp         d12,d13,[sp],#16
     ldp         d10,d11,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_chroma_ver.s
+++ b/common/arm64/ihevc_intra_pred_chroma_ver.s
@@ -87,16 +87,15 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevc_intra_pred_chroma_ver_av8
 
 .type ihevc_intra_pred_chroma_ver_av8, %function
 
-ihevc_intra_pred_chroma_ver_av8:
+ENTRY ihevc_intra_pred_chroma_ver_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
     push_v_regs
@@ -226,6 +225,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_filters_chroma_mode_11_to_17.s
+++ b/common/arm64/ihevc_intra_pred_filters_chroma_mode_11_to_17.s
@@ -88,9 +88,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_chroma_mode_11_to_17_av8, %function
 
-ihevc_intra_pred_chroma_mode_11_to_17_av8:
+ENTRY ihevc_intra_pred_chroma_mode_11_to_17_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -617,6 +616,7 @@ end_func:
     ldp         x19, x20,[sp],#16
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_filters_chroma_mode_19_to_25.s
+++ b/common/arm64/ihevc_intra_pred_filters_chroma_mode_19_to_25.s
@@ -88,9 +88,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevc_intra_pred_chroma_mode_19_to_25_av8
@@ -100,7 +99,7 @@
 
 .type ihevc_intra_pred_chroma_mode_19_to_25_av8, %function
 
-ihevc_intra_pred_chroma_mode_19_to_25_av8:
+ENTRY ihevc_intra_pred_chroma_mode_19_to_25_av8
 
     // stmfd sp!, {x4-x12, x14}             //stack stores the values of the arguments
 
@@ -571,6 +570,7 @@ end_loops:
     ldp         d8,d14,[sp],#16             // Loading d14 using { ldr d14,[sp]; add sp,sp,#8 } is giving bus error.
                                             // d8 is used as dummy register and loaded along with d14 using ldp. d8 is not used in the function.
     ldp         d12,d13,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_filters_luma_mode_11_to_17.s
+++ b/common/arm64/ihevc_intra_pred_filters_luma_mode_11_to_17.s
@@ -88,9 +88,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_luma_mode_11_to_17_av8, %function
 
-ihevc_intra_pred_luma_mode_11_to_17_av8:
+ENTRY ihevc_intra_pred_luma_mode_11_to_17_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -691,6 +690,7 @@ end_func:
     ldp         x19, x20,[sp],#16
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_filters_luma_mode_19_to_25.s
+++ b/common/arm64/ihevc_intra_pred_filters_luma_mode_19_to_25.s
@@ -88,9 +88,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -101,7 +100,7 @@
 
 .type ihevc_intra_pred_luma_mode_19_to_25_av8, %function
 
-ihevc_intra_pred_luma_mode_19_to_25_av8:
+ENTRY ihevc_intra_pred_luma_mode_19_to_25_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -661,6 +660,7 @@ end_loops:
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
     ldp         d9,d10,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_dc.s
+++ b/common/arm64/ihevc_intra_pred_luma_dc.s
@@ -92,16 +92,15 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevc_intra_pred_luma_dc_av8
 
 .type ihevc_intra_pred_luma_dc_av8, %function
 
-ihevc_intra_pred_luma_dc_av8:
+ENTRY ihevc_intra_pred_luma_dc_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -511,6 +510,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_horz.s
+++ b/common/arm64/ihevc_intra_pred_luma_horz.s
@@ -84,9 +84,8 @@
 //x2 => *pu1_dst
 //x3 =>  dst_strd
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -94,7 +93,7 @@
 
 .type ihevc_intra_pred_luma_horz_av8, %function
 
-ihevc_intra_pred_luma_horz_av8:
+ENTRY ihevc_intra_pred_luma_horz_av8
 
     // stmfd sp!, {x4-x12, x14}                //stack stores the values of the arguments
 
@@ -189,6 +188,7 @@ core_loop_32:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
     b           end_func
 
@@ -269,6 +269,7 @@ core_loop_16:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
     b           end_func
 
@@ -315,6 +316,7 @@ core_loop_8:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
     b           end_func
 
@@ -350,6 +352,7 @@ core_loop_4:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 end_func:
 

--- a/common/arm64/ihevc_intra_pred_luma_mode2.s
+++ b/common/arm64/ihevc_intra_pred_luma_mode2.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_luma_mode2_av8, %function
 
-ihevc_intra_pred_luma_mode2_av8:
+ENTRY ihevc_intra_pred_luma_mode2_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
 
@@ -270,6 +269,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_mode_18_34.s
+++ b/common/arm64/ihevc_intra_pred_luma_mode_18_34.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -102,7 +101,7 @@
 
 .type ihevc_intra_pred_luma_mode_18_34_av8, %function
 
-ihevc_intra_pred_luma_mode_18_34_av8:
+ENTRY ihevc_intra_pred_luma_mode_18_34_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
     push_v_regs
@@ -278,6 +277,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_mode_27_to_33.s
+++ b/common/arm64/ihevc_intra_pred_luma_mode_27_to_33.s
@@ -85,9 +85,8 @@
 //x2 => *pu1_dst
 //x3 =>  dst_strd
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -97,7 +96,7 @@
 
 .type ihevc_intra_pred_luma_mode_27_to_33_av8, %function
 
-ihevc_intra_pred_luma_mode_27_to_33_av8:
+ENTRY ihevc_intra_pred_luma_mode_27_to_33_av8
 
     // stmfd sp!, {x4-x12, x14}                //stack stores the values of the arguments
 
@@ -554,6 +553,7 @@ end_loops:
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
     ldp         d9,d10,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_mode_3_to_9.s
+++ b/common/arm64/ihevc_intra_pred_luma_mode_3_to_9.s
@@ -88,9 +88,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -103,7 +102,7 @@
 
 .type ihevc_intra_pred_luma_mode_3_to_9_av8, %function
 
-ihevc_intra_pred_luma_mode_3_to_9_av8:
+ENTRY ihevc_intra_pred_luma_mode_3_to_9_av8
 
     // stmfd sp!, {x4-x12, x14}        //stack stores the values of the arguments
 
@@ -563,6 +562,7 @@ end_func:
     ldp         x19, x20,[sp],#16
     ldp         d14,d15,[sp],#16
     ldp         d12,d13,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_planar.s
+++ b/common/arm64/ihevc_intra_pred_luma_planar.s
@@ -92,9 +92,8 @@
 //    mode
 //    pi1_coeff
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -104,7 +103,7 @@
 
 .type ihevc_intra_pred_luma_planar_av8, %function
 
-ihevc_intra_pred_luma_planar_av8:
+ENTRY ihevc_intra_pred_luma_planar_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -558,6 +557,7 @@ end_loop:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_intra_pred_luma_vert.s
+++ b/common/arm64/ihevc_intra_pred_luma_vert.s
@@ -88,9 +88,8 @@
 //    nt
 //    mode
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -98,7 +97,7 @@
 
 .type ihevc_intra_pred_luma_ver_av8, %function
 
-ihevc_intra_pred_luma_ver_av8:
+ENTRY ihevc_intra_pred_luma_ver_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -424,6 +423,7 @@ end_func:
     // ldmfd sp!,{x4-x12,x15}                  //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_itrans_recon_16x16.s
+++ b/common/arm64/ihevc_itrans_recon_16x16.s
@@ -105,10 +105,8 @@
 //    x12
 //    x11
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -123,7 +121,7 @@
 
 .type ihevc_itrans_recon_16x16_av8, %function
 
-ihevc_itrans_recon_16x16_av8:
+ENTRY ihevc_itrans_recon_16x16_av8
 
     ldr         w11, [sp]
     // stmfd sp!,{x4-x12,x14}
@@ -1226,6 +1224,7 @@ skip_last8rows_stage2_kernel2:
     // ldmfd sp!,{x4-x12,pc}
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_itrans_recon_32x32.s
+++ b/common/arm64/ihevc_itrans_recon_32x32.s
@@ -124,9 +124,8 @@
 //d5[2]= 43        d7[2]=9
 //d5[3]= 38        d7[3]=4
 
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -143,7 +142,7 @@
 
 .type ihevc_itrans_recon_32x32_av8, %function
 
-ihevc_itrans_recon_32x32_av8:
+ENTRY ihevc_itrans_recon_32x32_av8
 
     ldr         w11, [sp]
 
@@ -3042,6 +3041,7 @@ prediction_buffer:
     // ldmfd sp!,{x0-x12,pc}
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_itrans_recon_4x4.s
+++ b/common/arm64/ihevc_itrans_recon_4x4.s
@@ -100,10 +100,8 @@
 //    x6 => dst_strd
 //    x7 => zero_cols
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .set shift_stage1_idct ,   7
 .set shift_stage2_idct ,   12
@@ -116,7 +114,7 @@
 
 .type ihevc_itrans_recon_4x4_av8, %function
 
-ihevc_itrans_recon_4x4_av8:
+ENTRY ihevc_itrans_recon_4x4_av8
 
     // stmfd sp!, {x4-x12, x14}                //stack stores the values of the arguments
 
@@ -229,6 +227,7 @@ ihevc_itrans_recon_4x4_av8:
     // ldmfd sp!,{x4-x12,x15}                //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_itrans_recon_4x4_ttype1.s
+++ b/common/arm64/ihevc_itrans_recon_4x4_ttype1.s
@@ -103,10 +103,8 @@
 //    x6 => dst_strd
 //    x7 => zero_cols
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .set shift_stage1_idct ,   7
 .set shift_stage2_idct ,   12
@@ -115,7 +113,7 @@
 
 .type ihevc_itrans_recon_4x4_ttype1_av8, %function
 
-ihevc_itrans_recon_4x4_ttype1_av8:
+ENTRY ihevc_itrans_recon_4x4_ttype1_av8
 
     // stmfd sp!, {x4-x12, x14}    //stack stores the values of the arguments
 
@@ -234,6 +232,7 @@ ihevc_itrans_recon_4x4_ttype1_av8:
     // ldmfd sp!,{x4-x12,x15}            //reload the registers from sp
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_itrans_recon_8x8.s
+++ b/common/arm64/ihevc_itrans_recon_8x8.s
@@ -105,10 +105,8 @@
 //    zero_cols
 
 
-
-.text
-.align 4
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -123,7 +121,7 @@
 
 .type ihevc_itrans_recon_8x8_av8, %function
 
-ihevc_itrans_recon_8x8_av8:
+ENTRY ihevc_itrans_recon_8x8_av8
 ////register usage.extern        - loading and until idct of columns
 ////    cosine constants     -     d0
 ////    sine constants         -     d1
@@ -1030,6 +1028,7 @@ pred_buff_addition:
     // ldmfd sp!,{x4-x12,pc}
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_mem_fns.s
+++ b/common/arm64/ihevc_mem_fns.s
@@ -69,14 +69,14 @@
 //    x1 => *pu1_src
 //    x2 => num_bytes
 
+.include "ihevc_neon_macros.s"
 .text
-.p2align 2
 
 
     .global ihevc_memcpy_mul_8_av8
 .type ihevc_memcpy_mul_8_av8, %function
 
-ihevc_memcpy_mul_8_av8:
+ENTRY ihevc_memcpy_mul_8_av8
 
 LOOP_NEON_MEMCPY_MUL_8:
     // Memcpy 8 bytes
@@ -85,6 +85,7 @@ LOOP_NEON_MEMCPY_MUL_8:
 
     SUBS        x2,x2,#8
     BNE         LOOP_NEON_MEMCPY_MUL_8
+    EXIT_FUNC
     ret
 
 
@@ -104,7 +105,7 @@ LOOP_NEON_MEMCPY_MUL_8:
     .global ihevc_memcpy_av8
 .type ihevc_memcpy_av8, %function
 
-ihevc_memcpy_av8:
+ENTRY ihevc_memcpy_av8
     SUBS        x2,x2,#8
     BLT         ARM_MEMCPY
 LOOP_NEON_MEMCPY:
@@ -126,6 +127,7 @@ LOOP_ARM_MEMCPY:
     SUBS        x2,x2,#1
     BNE         LOOP_ARM_MEMCPY
 MEMCPY_RETURN:
+    EXIT_FUNC
     ret
 
 
@@ -140,14 +142,13 @@ MEMCPY_RETURN:
 //    x2 => num_bytes
 
 .text
-.p2align 2
 
 
 
     .global ihevc_memset_mul_8_av8
 .type ihevc_memset_mul_8_av8, %function
 
-ihevc_memset_mul_8_av8:
+ENTRY ihevc_memset_mul_8_av8
 
 // Assumptions: numbytes is either 8, 16 or 32
     dup         v0.8b,w1
@@ -158,6 +159,7 @@ LOOP_MEMSET_MUL_8:
     SUBS        x2,x2,#8
     BNE         LOOP_MEMSET_MUL_8
 
+    EXIT_FUNC
     ret
 
 
@@ -176,7 +178,7 @@ LOOP_MEMSET_MUL_8:
     .global ihevc_memset_av8
 .type ihevc_memset_av8, %function
 
-ihevc_memset_av8:
+ENTRY ihevc_memset_av8
     SUBS        x2,x2,#8
     BLT         ARM_MEMSET
     dup         v0.8b,w1
@@ -198,6 +200,7 @@ LOOP_ARM_MEMSET:
     BNE         LOOP_ARM_MEMSET
 
 MEMSET_RETURN:
+    EXIT_FUNC
     ret
 
 
@@ -212,14 +215,13 @@ MEMSET_RETURN:
 //    x2 => num_words
 
 .text
-.p2align 2
 
 
 
     .global ihevc_memset_16bit_mul_8_av8
 .type ihevc_memset_16bit_mul_8_av8, %function
 
-ihevc_memset_16bit_mul_8_av8:
+ENTRY ihevc_memset_16bit_mul_8_av8
 
 // Assumptions: num_words is either 8, 16 or 32
 
@@ -231,6 +233,7 @@ LOOP_MEMSET_16BIT_MUL_8:
     SUBS        x2,x2,#8
     BNE         LOOP_MEMSET_16BIT_MUL_8
 
+    EXIT_FUNC
     ret
 
 
@@ -249,7 +252,7 @@ LOOP_MEMSET_16BIT_MUL_8:
     .global ihevc_memset_16bit_av8
 .type ihevc_memset_16bit_av8, %function
 
-ihevc_memset_16bit_av8:
+ENTRY ihevc_memset_16bit_av8
     SUBS        x2,x2,#8
     BLT         ARM_MEMSET_16BIT
     dup         v0.8h,w1
@@ -271,6 +274,7 @@ LOOP_ARM_MEMSET_16BIT:
     BNE         LOOP_ARM_MEMSET_16BIT
 
 MEMSET_16BIT_RETURN:
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_neon_macros.s
+++ b/common/arm64/ihevc_neon_macros.s
@@ -47,3 +47,53 @@
     ldp         d10,d11,[sp],#16
     ldp         d8,d9,[sp],#16
 .endm
+
+// --- Internal Security Dispatchers ---
+// These expand to real instructions only if the compiler flags are present.
+
+.macro BTI_ENABLE
+#if defined(__ARM_FEATURE_BTI_DEFAULT)
+    bti c
+#endif
+.endm
+
+.macro PAC_ENTRY
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+    paciasp
+#endif
+.endm
+
+.macro PAC_EXIT
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+    autiasp
+#endif
+.endm
+
+// --- Main ENTRY and EXIT_FUNC Macros ---
+
+.macro ENTRY name
+    .p2align 2
+\name:
+    BTI_ENABLE
+    PAC_ENTRY
+.endm
+
+.macro EXIT_FUNC
+    PAC_EXIT
+.endm
+
+// --- GNU Property Note ---
+// Signals BTI and PAC support to the Android linker.
+#if defined(__linux__) && defined(__aarch64__)
+    .pushsection .note.gnu.property, "a"  // Switch to Note section
+    .p2align 3
+    .word 4           // Name size
+    .word 16          // Data size
+    .word 5           // NT_GNU_PROPERTY_TYPE_0
+    .asciz "GNU"      // Owner
+    .word 0xc0000000  // GNU_PROPERTY_AARCH64_FEATURE_1_AND
+    .word 4           // Data size
+    .word 3           // Value: BTI (Bit 0) | PAC (Bit 1)
+    .word 0           // Padding
+    .popsection                           // Switch back to previous section
+#endif

--- a/common/arm64/ihevc_padding.s
+++ b/common/arm64/ihevc_padding.s
@@ -85,14 +85,14 @@
 //    x2 => ht
 //    x3 => pad_size
 
+.include "ihevc_neon_macros.s"
 .text
-.align 4
 
 .globl ihevc_pad_left_luma_av8
 
 .type ihevc_pad_left_luma_av8, %function
 
-ihevc_pad_left_luma_av8:
+ENTRY ihevc_pad_left_luma_av8
 
 loop_start_luma_left:
     // pad size is assumed to be pad_left = 80
@@ -148,6 +148,7 @@ loop_start_luma_left:
 
     bne         loop_start_luma_left
 
+    EXIT_FUNC
     ret
 
 
@@ -209,7 +210,7 @@ loop_start_luma_left:
 
 .type ihevc_pad_left_chroma_av8, %function
 
-ihevc_pad_left_chroma_av8:
+ENTRY ihevc_pad_left_chroma_av8
 
 
 loop_start_chroma_left:
@@ -266,6 +267,7 @@ loop_start_chroma_left:
 
     bne         loop_start_chroma_left
 
+    EXIT_FUNC
     ret
 
 
@@ -337,7 +339,7 @@ loop_start_chroma_left:
 
 .type ihevc_pad_right_luma_av8, %function
 
-ihevc_pad_right_luma_av8:
+ENTRY ihevc_pad_right_luma_av8
 
 
 loop_start_luma_right:
@@ -395,6 +397,7 @@ loop_start_luma_right:
 
     bne         loop_start_luma_right
 
+    EXIT_FUNC
     ret
 
 
@@ -455,7 +458,7 @@ loop_start_luma_right:
 
 .type ihevc_pad_right_chroma_av8, %function
 
-ihevc_pad_right_chroma_av8:
+ENTRY ihevc_pad_right_chroma_av8
 
 
 loop_start_chroma_right:
@@ -512,6 +515,7 @@ loop_start_chroma_right:
 
     bne         loop_start_chroma_right
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_band_offset_chroma.s
+++ b/common/arm64/ihevc_sao_band_offset_chroma.s
@@ -61,14 +61,13 @@
 //x9    =>    wd 60
 //x10=>    ht 64
 
-.text
-.p2align 2
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gu1_table_band_idx
 .globl ihevc_sao_band_offset_chroma_av8
 
-ihevc_sao_band_offset_chroma_av8:
+ENTRY ihevc_sao_band_offset_chroma_av8
     mov         x8,#0
     mov         x9,#0
     mov         x10,#0
@@ -424,6 +423,7 @@ END_LOOP:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_band_offset_luma.s
+++ b/common/arm64/ihevc_sao_band_offset_luma.s
@@ -65,12 +65,11 @@
 .include "ihevc_neon_macros.s"
 
 .text
-.p2align 2
 
 .globl gu1_table_band_idx
 .globl ihevc_sao_band_offset_luma_av8
 
-ihevc_sao_band_offset_luma_av8:
+ENTRY ihevc_sao_band_offset_luma_av8
 
     // STMFD sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -244,6 +243,7 @@ HEIGHT_LOOP:
     ldp         d8,d15,[sp],#16             // Loading d15 using { ldr d15,[sp]; add sp,sp,#8 } is giving bus error.
                                             // d8 is used as dummy register and loaded along with d15 using ldp. d8 is not used in the function.
     ldp         d13,d14,[sp],#16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class0.s
+++ b/common/arm64/ihevc_sao_edge_offset_class0.s
@@ -59,15 +59,14 @@
 //x9    =>    wd
 //x10=>    ht
 
-.text
-.p2align 2
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class0_av8
 
-ihevc_sao_edge_offset_class0_av8:
+ENTRY ihevc_sao_edge_offset_class0_av8
 
 
     // STMFD sp!, {x4-x12, x14}            //stack stores the values of the arguments
@@ -338,6 +337,7 @@ END_LOOPS:
     // LDMFD sp!,{x4-x12,x15}              //Reload the registers from SP
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class0_chroma.s
+++ b/common/arm64/ihevc_sao_edge_offset_class0_chroma.s
@@ -60,14 +60,13 @@
 //x9    =>    wd
 //x10=>    ht
 
-.text
-.p2align 2
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class0_chroma_av8
 
-ihevc_sao_edge_offset_class0_chroma_av8:
+ENTRY ihevc_sao_edge_offset_class0_chroma_av8
 
     ldr         x8,[sp,#0]
     ldr         x9,[sp,#8]
@@ -477,6 +476,7 @@ END_LOOPS:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class1.s
+++ b/common/arm64/ihevc_sao_edge_offset_class1.s
@@ -58,15 +58,14 @@
 //x7    =>    wd
 //x8 =>    ht
 
-.text
-.p2align 2
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class1_av8
 
-ihevc_sao_edge_offset_class1_av8:
+ENTRY ihevc_sao_edge_offset_class1_av8
 
 
     // STMFD sp!, {x4-x12, x14}            //stack stores the values of the arguments
@@ -355,6 +354,7 @@ END_LOOPS:
     // LDMFD sp!,{x4-x12,x15}             //Reload the registers from SP
     ldp         x19, x20,[sp], #16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class1_chroma.s
+++ b/common/arm64/ihevc_sao_edge_offset_class1_chroma.s
@@ -60,14 +60,13 @@
 //x8    =>    wd
 //x9 =>    ht
 
-.text
-.p2align 2
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class1_chroma_av8
 
-ihevc_sao_edge_offset_class1_chroma_av8:
+ENTRY ihevc_sao_edge_offset_class1_chroma_av8
 
 
     ldr         x8,[sp,#0]
@@ -458,6 +457,7 @@ END_LOOPS:
     ldp         x19, x20,[sp],#16
 
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class2.s
+++ b/common/arm64/ihevc_sao_edge_offset_class2.s
@@ -58,15 +58,14 @@
 //x7    =>    wd
 //x8=>    ht
 
-.text
-.p2align 2
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class2_av8
 
-ihevc_sao_edge_offset_class2_av8:
+ENTRY ihevc_sao_edge_offset_class2_av8
 
 
     // STMFD sp!,{x4-x12,x14}            //stack stores the values of the arguments
@@ -846,6 +845,7 @@ END_LOOPS:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class2_chroma.s
+++ b/common/arm64/ihevc_sao_edge_offset_class2_chroma.s
@@ -60,14 +60,13 @@
 //x7    =>    wd
 //x8=>    ht
 
-.text
-.p2align 2
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class2_chroma_av8
 
-ihevc_sao_edge_offset_class2_chroma_av8:
+ENTRY ihevc_sao_edge_offset_class2_chroma_av8
 
 
     // STMFD sp!,{x4-x12,x14}            //stack stores the values of the arguments
@@ -1132,6 +1131,7 @@ END_LOOPS:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class3.s
+++ b/common/arm64/ihevc_sao_edge_offset_class3.s
@@ -58,15 +58,14 @@
 //x7    =>    wd
 //x8=>    ht
 
-.text
-.p2align 2
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class3_av8
 
-ihevc_sao_edge_offset_class3_av8:
+ENTRY ihevc_sao_edge_offset_class3_av8
 
 
     // STMFD sp!,{x4-x12,x14}            //stack stores the values of the arguments
@@ -889,6 +888,7 @@ END_LOOPS:
     ldp         x23, x24,[sp], #16
     ldp         x21, x22,[sp], #16
     ldp         x19, x20,[sp], #16
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_sao_edge_offset_class3_chroma.s
+++ b/common/arm64/ihevc_sao_edge_offset_class3_chroma.s
@@ -60,13 +60,12 @@
 //x7    =>    wd
 //x8=>    ht
 
-.text
-.p2align 2
 .include "ihevc_neon_macros.s"
+.text
 .globl gi1_table_edge_idx
 .globl ihevc_sao_edge_offset_class3_chroma_av8
 
-ihevc_sao_edge_offset_class3_chroma_av8:
+ENTRY ihevc_sao_edge_offset_class3_chroma_av8
 
 
     // STMFD sp!,{x4-x12,x14}            //stack stores the values of the arguments
@@ -1167,6 +1166,7 @@ END_LOOPS:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_weighted_pred_bi.s
+++ b/common/arm64/ihevc_weighted_pred_bi.s
@@ -134,16 +134,14 @@
 //    x14 =>    ht
 //    x7    =>    wd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_weighted_pred_bi_av8
 
 .type ihevc_weighted_pred_bi_av8, %function
 
-ihevc_weighted_pred_bi_av8:
+ENTRY ihevc_weighted_pred_bi_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -307,6 +305,7 @@ end_loops:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_weighted_pred_bi_default.s
+++ b/common/arm64/ihevc_weighted_pred_bi_default.s
@@ -107,16 +107,15 @@
 //    x7 =>  lvl_shift2
 //    x8 =>  ht
 //    x9 =>  wd
-.text
-.align 4
 
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_weighted_pred_bi_default_av8
 
 .type ihevc_weighted_pred_bi_default_av8, %function
 
-ihevc_weighted_pred_bi_default_av8:
+ENTRY ihevc_weighted_pred_bi_default_av8
 
     ldr         w8,[sp,#0]
     ldr         w9,[sp,#8]
@@ -534,6 +533,7 @@ end_loops:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/common/arm64/ihevc_weighted_pred_uni.s
+++ b/common/arm64/ihevc_weighted_pred_uni.s
@@ -112,16 +112,14 @@
 //    x8 =>    ht
 //    x9    =>    wd
 
-.text
-.align 4
-
 .include "ihevc_neon_macros.s"
+.text
 
 .globl ihevc_weighted_pred_uni_av8
 
 .type ihevc_weighted_pred_uni_av8, %function
 
-ihevc_weighted_pred_uni_av8:
+ENTRY ihevc_weighted_pred_uni_av8
 
     // stmfd sp!, {x4-x12, x14}            //stack stores the values of the arguments
 
@@ -240,6 +238,7 @@ end_loops:
     ldp         x21, x22,[sp],#16
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/decoder/arm64/ihevcd_fmt_conv_420sp_to_420p.s
+++ b/decoder/arm64/ihevcd_fmt_conv_420sp_to_420p.s
@@ -34,9 +34,8 @@
 //*
 //*******************************************************************************/
 
-.text
-
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -84,7 +83,7 @@
 
 .type ihevcd_fmt_conv_420sp_to_420p_av8, %function
 
-ihevcd_fmt_conv_420sp_to_420p_av8:
+ENTRY ihevcd_fmt_conv_420sp_to_420p_av8
     // STMFD sp!,{x4-x12, x14}
     push_v_regs
     stp         x19, x20,[sp,#-16]!
@@ -200,6 +199,7 @@ exit:
     // LDMFD sp!,{x4-x12, pc}
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/decoder/arm64/ihevcd_fmt_conv_420sp_to_420sp.s
+++ b/decoder/arm64/ihevcd_fmt_conv_420sp_to_420sp.s
@@ -39,10 +39,9 @@
     //
     // PRESERVE8
 
-.text
-.p2align 2
 
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -85,7 +84,7 @@
 
     .global ihevcd_fmt_conv_420sp_to_420sp_av8
 .type ihevcd_fmt_conv_420sp_to_420sp_a9q, %function
-ihevcd_fmt_conv_420sp_to_420sp_av8:
+ENTRY ihevcd_fmt_conv_420sp_to_420sp_av8
 
     // STMFD sp!,{x4-x12, x14}
     push_v_regs
@@ -200,6 +199,7 @@ exit:
     // LDMFD sp!,{x4-x12, pc}
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/decoder/arm64/ihevcd_itrans_recon_dc_chroma.s
+++ b/decoder/arm64/ihevcd_itrans_recon_dc_chroma.s
@@ -35,15 +35,15 @@
 //*******************************************************************************/
 
 
-.text
 .include "ihevc_neon_macros.s"
+.text
 
 
 .globl ihevcd_itrans_recon_dc_chroma_av8
 
 .type ihevcd_itrans_recon_dc_chroma_av8, %function
 
-ihevcd_itrans_recon_dc_chroma_av8:
+ENTRY ihevcd_itrans_recon_dc_chroma_av8
 
 //void ihevcd_itrans_recon_dc_chroma(uword8 *pu1_pred,
 //                            uword8 *pu1_dst,
@@ -215,6 +215,7 @@ col_loop_4chroma:
 end_loops_chroma:
     ldp         x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/decoder/arm64/ihevcd_itrans_recon_dc_luma.s
+++ b/decoder/arm64/ihevcd_itrans_recon_dc_luma.s
@@ -34,8 +34,8 @@
 //*
 //*******************************************************************************/
 
-.text
 .include "ihevc_neon_macros.s"
+.text
 
 
 
@@ -43,7 +43,7 @@
 
 .type ihevcd_itrans_recon_dc_luma_av8, %function
 
-ihevcd_itrans_recon_dc_luma_av8:
+ENTRY ihevcd_itrans_recon_dc_luma_av8
 
 //void ihevcd_itrans_recon_dc_luma(uword8 *pu1_pred,
 //                            uword8 *pu1_dst,
@@ -207,6 +207,7 @@ col_loop_4:
 end_loops:
     ldp         x19, x20,[sp],#16
 
+    EXIT_FUNC
     ret
 
 

--- a/fuzzer/Android.bp
+++ b/fuzzer/Android.bp
@@ -9,10 +9,6 @@ package {
 
 cc_fuzz {
     name: "hevc_dec_fuzzer",
-    //TODO: b/485868924
-    defaults: [
-        "no_bti",
-    ],
     host_supported: true,
     srcs: [
         "hevc_dec_fuzzer.cpp",
@@ -45,10 +41,6 @@ cc_fuzz {
 
 cc_fuzz {
     name: "hevc_enc_fuzzer",
-    //TODO: b/485868924
-    defaults: [
-        "no_bti",
-    ],
     host_supported: true,
     srcs: [
         "hevc_enc_fuzzer.cpp",


### PR DESCRIPTION
Test: readelf -nw libhevcdec.a
Test: readelf -nW libhevcenc.a
Test: atest MctsMediaV2TestCases
      atest MctsMediaDecoderTestCases
      atest MctsMediaEncoderTestCases
      atest MctsMediaCodecTestCases
Test: hevc_dec_fuzzer
      hevc_enc_fuzzer
Bug: 485868924
Change-Id: I7eb3c915662654d649ba4aa5793f71afff8c47e7