### PR TITLE
libhevcdec: Add support for odd dimensions

### DIFF
--- a/decoder/ihevcd_api.c
+++ b/decoder/ihevcd_api.c
@@ -2713,36 +2713,39 @@ WORD32 ihevcd_get_status(iv_obj_t *ps_codec_obj,
     }
 
     /*!*/
+    WORD32 aligned_wd = ALIGN2(wd);
+    WORD32 aligned_ht = ALIGN2(ht);
     if(ps_codec->e_chroma_fmt == IV_YUV_420P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht) >> 2;
-        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht) >> 2;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * (aligned_ht >> 1);
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_444P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht);
     }
     else if((ps_codec->e_chroma_fmt == IV_YUV_420SP_UV)
                     || (ps_codec->e_chroma_fmt == IV_YUV_420SP_VU))
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht) >> 1;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        ps_ctl_op->u4_min_out_buf_size[1] <<= 1;
         ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
         ps_ctl_op->u4_min_out_buf_size[1] = 0;
         ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht) >> 1;
-        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht) >> 1;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * aligned_ht;
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * aligned_ht;
     }
     ps_ctl_op->u4_pic_ht = ht;
     ps_ctl_op->u4_pic_wd = wd;
@@ -2901,36 +2904,38 @@ WORD32 ihevcd_get_buf_info(iv_obj_t *ps_codec_obj,
     }
 
     /*!*/
+    WORD32 aligned_wd = ALIGN2(wd);
+    WORD32 aligned_ht = ALIGN2(ht);
     if(ps_codec->e_chroma_fmt == IV_YUV_420P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht) >> 2;
-        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht) >> 2;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * (aligned_ht >> 1);
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_444P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht);
     }
     else if((ps_codec->e_chroma_fmt == IV_YUV_420SP_UV)
                     || (ps_codec->e_chroma_fmt == IV_YUV_420SP_VU))
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht) >> 1;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        ps_ctl_op->u4_min_out_buf_size[1] <<= 1;
         ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] =
-                        ps_ctl_op->u4_min_out_buf_size[2] = 0;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht) >> 1;
-        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht) >> 1;
+        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * aligned_ht;
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * aligned_ht;
     }
     ps_codec->i4_num_disp_bufs = ps_ctl_op->u4_num_disp_bufs;
 
@@ -3301,9 +3306,9 @@ WORD32 ihevcd_get_frame_dimensions(iv_obj_t *ps_codec_obj,
                     >> 1);
     ps_op->u4_disp_ht[1] = ps_op->u4_disp_ht[2] = ((ps_op->u4_disp_ht[0] + 1)
                     >> 1);
-    ps_op->u4_buffer_wd[1] = ps_op->u4_buffer_wd[2] = (ps_op->u4_buffer_wd[0]
+    ps_op->u4_buffer_wd[1] = ps_op->u4_buffer_wd[2] = ((ps_op->u4_buffer_wd[0] + 1)
                     >> 1);
-    ps_op->u4_buffer_ht[1] = ps_op->u4_buffer_ht[2] = (ps_op->u4_buffer_ht[0]
+    ps_op->u4_buffer_ht[1] = ps_op->u4_buffer_ht[2] = ((ps_op->u4_buffer_ht[0] + 1)
                     >> 1);
     ps_op->u4_x_offset[1] = ps_op->u4_x_offset[2] = (ps_op->u4_x_offset[0]
                     >> 1);
@@ -3331,6 +3336,12 @@ WORD32 ihevcd_get_frame_dimensions(iv_obj_t *ps_codec_obj,
         ps_op->u4_buffer_wd[1] = ps_op->u4_buffer_wd[2] = ps_op->u4_buffer_wd[0];
         ps_op->u4_buffer_ht[1] = ps_op->u4_buffer_ht[2] = ps_op->u4_buffer_ht[0];
         ps_op->u4_x_offset[1] = ps_op->u4_x_offset[2] = ps_op->u4_x_offset[0];
+        ps_op->u4_y_offset[1] = ps_op->u4_y_offset[2] = ps_op->u4_y_offset[0];
+    }
+    else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
+    {
+        ps_op->u4_disp_ht[1] = ps_op->u4_disp_ht[2] = ps_op->u4_disp_ht[0];
+        ps_op->u4_buffer_ht[1] = ps_op->u4_buffer_ht[2] = ps_op->u4_buffer_ht[0];
         ps_op->u4_y_offset[1] = ps_op->u4_y_offset[2] = ps_op->u4_y_offset[0];
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)

--- a/decoder/ihevcd_decode.c
+++ b/decoder/ihevcd_decode.c
@@ -325,41 +325,32 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
                             ps_dec_ip->s_out_buffer.pu1_bufs[1];
             ps_dec_op->s_disp_frm_buf.pv_v_buf =
                             ps_dec_ip->s_out_buffer.pu1_bufs[2];
-            ps_dec_op->s_disp_frm_buf.u4_y_strd = ps_codec->i4_disp_strd;
+            ps_dec_op->s_disp_frm_buf.u4_y_strd = ALIGN2(ps_codec->i4_disp_strd);
         }
 
         if((IV_YUV_420SP_VU == ps_codec->e_chroma_fmt)
                         || (IV_YUV_420SP_UV == ps_codec->e_chroma_fmt))
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_strd;
+            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd);
             ps_dec_op->s_disp_frm_buf.u4_v_strd = 0;
-            ps_dec_op->s_disp_frm_buf.u4_u_wd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_wd;
+            ps_dec_op->s_disp_frm_buf.u4_u_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd);
             ps_dec_op->s_disp_frm_buf.u4_v_wd = 0;
-            ps_dec_op->s_disp_frm_buf.u4_u_ht =
-                            ps_dec_op->s_disp_frm_buf.u4_y_ht / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht) / 2;
             ps_dec_op->s_disp_frm_buf.u4_v_ht = 0;
         }
         else if(IV_YUV_420P == ps_codec->e_chroma_fmt)
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_strd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_u_wd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_wd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_wd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_wd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_u_ht =
-                            ps_dec_op->s_disp_frm_buf.u4_y_ht / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_ht =
-                            ps_dec_op->s_disp_frm_buf.u4_y_ht / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht) / 2;
         }
         else if(IV_YUV_444P == ps_codec->e_chroma_fmt)
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd = ps_dec_op->s_disp_frm_buf.u4_y_strd;
-            ps_dec_op->s_disp_frm_buf.u4_v_strd = ps_dec_op->s_disp_frm_buf.u4_y_strd;
+            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd);
+            ps_dec_op->s_disp_frm_buf.u4_v_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd);
             ps_dec_op->s_disp_frm_buf.u4_u_wd = ps_dec_op->s_disp_frm_buf.u4_y_wd;
             ps_dec_op->s_disp_frm_buf.u4_v_wd = ps_dec_op->s_disp_frm_buf.u4_y_wd;
             ps_dec_op->s_disp_frm_buf.u4_u_ht = ps_dec_op->s_disp_frm_buf.u4_y_ht;
@@ -376,18 +367,12 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
         }
         else if(IV_YUV_422P == ps_codec->e_chroma_fmt)
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_strd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_u_wd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_wd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_wd =
-                            ps_dec_op->s_disp_frm_buf.u4_y_wd / 2;
-            ps_dec_op->s_disp_frm_buf.u4_u_ht =
-                            ps_dec_op->s_disp_frm_buf.u4_y_ht;
-            ps_dec_op->s_disp_frm_buf.u4_v_ht =
-                            ps_dec_op->s_disp_frm_buf.u4_y_ht;
+            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht);
+            ps_dec_op->s_disp_frm_buf.u4_v_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht);
         }
 
     }

--- a/decoder/ihevcd_fmt_conv.c
+++ b/decoder/ihevcd_fmt_conv.c
@@ -70,6 +70,71 @@
 /**
 *******************************************************************************
 *
+* @brief Function used from copying a 400 buffer
+*
+* @par   Description
+* Function used from copying a 400 buffer
+*
+* @param[in] pu1_y_src
+*   Input Y pointer
+*
+* @param[in] pu1_y_dst
+*   Output Y pointer
+*
+* @param[in] wd
+*   Width
+*
+* @param[in] ht
+*   Height
+*
+* @param[in] src_y_strd
+*   Input Y Stride
+*
+* @param[in] dst_y_strd
+*   Output Y stride
+*
+* @returns None
+*
+* @remarks In case there is a need to perform partial frame copy then
+* by passion appropriate source and destination pointers and appropriate
+* values for wd and ht it can be done
+*
+*******************************************************************************
+*/
+
+void ihevcd_fmt_conv_luma_copy(UWORD8 *pu1_y_src,
+                               UWORD8 *pu1_y_dst,
+                               WORD32 wd,
+                               WORD32 ht,
+                               WORD32 src_y_strd,
+                               WORD32 dst_y_strd)
+{
+    UWORD8 *pu1_src, *pu1_dst;
+    WORD32 num_rows, num_cols, src_strd, dst_strd;
+    WORD32 i;
+
+    /* copy luma */
+    pu1_src = (UWORD8 *)pu1_y_src;
+    pu1_dst = (UWORD8 *)pu1_y_dst;
+
+    num_rows = ALIGN2(ht);
+    num_cols = ALIGN2(wd);
+
+    src_strd = src_y_strd;
+    dst_strd = dst_y_strd;
+
+    for(i = 0; i < num_rows; i++)
+    {
+        memcpy(pu1_dst, pu1_src, num_cols);
+        pu1_dst += dst_strd;
+        pu1_src += src_strd;
+    }
+    return;
+}
+
+/**
+*******************************************************************************
+*
 * @brief Function used from copying a 420SP buffer
 *
 * @par   Description
@@ -125,108 +190,21 @@ void ihevcd_fmt_conv_420sp_to_420sp(UWORD8 *pu1_y_src,
                                     WORD32 dst_y_strd,
                                     WORD32 dst_uv_strd)
 {
-    UWORD8 *pu1_src, *pu1_dst;
-    WORD32 num_rows, num_cols, src_strd, dst_strd;
+    WORD32 num_rows, num_cols;
     WORD32 i;
 
     /* copy luma */
-    pu1_src = (UWORD8 *)pu1_y_src;
-    pu1_dst = (UWORD8 *)pu1_y_dst;
-
-    num_rows = ht;
-    num_cols = wd;
-
-    src_strd = src_y_strd;
-    dst_strd = dst_y_strd;
-
-    for(i = 0; i < num_rows; i++)
-    {
-        memcpy(pu1_dst, pu1_src, num_cols);
-        pu1_dst += dst_strd;
-        pu1_src += src_strd;
-    }
+    ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
 
     /* copy U and V */
-    pu1_src = (UWORD8 *)pu1_uv_src;
-    pu1_dst = (UWORD8 *)pu1_uv_dst;
-
-    num_rows = ht >> 1;
-    num_cols = wd;
-
-    src_strd = src_uv_strd;
-    dst_strd = dst_uv_strd;
+    num_rows = (ht + 1) >> 1;
+    num_cols = ALIGN2(wd);
 
     for(i = 0; i < num_rows; i++)
     {
-        memcpy(pu1_dst, pu1_src, num_cols);
-        pu1_dst += dst_strd;
-        pu1_src += src_strd;
-    }
-    return;
-}
-
-
-/**
-*******************************************************************************
-*
-* @brief Function used from copying a 400 buffer
-*
-* @par   Description
-* Function used from copying a 400 buffer
-*
-* @param[in] pu1_y_src
-*   Input Y pointer
-*
-* @param[in] pu1_y_dst
-*   Output Y pointer
-*
-* @param[in] wd
-*   Width
-*
-* @param[in] ht
-*   Height
-*
-* @param[in] src_y_strd
-*   Input Y Stride
-*
-* @param[in] dst_y_strd
-*   Output Y stride
-*
-* @returns None
-*
-* @remarks In case there is a need to perform partial frame copy then
-* by passion appropriate source and destination pointers and appropriate
-* values for wd and ht it can be done
-*
-*******************************************************************************
-*/
-
-void ihevcd_fmt_conv_luma_copy(UWORD8 *pu1_y_src,
-                               UWORD8 *pu1_y_dst,
-                               WORD32 wd,
-                               WORD32 ht,
-                               WORD32 src_y_strd,
-                               WORD32 dst_y_strd)
-{
-    UWORD8 *pu1_src, *pu1_dst;
-    WORD32 num_rows, num_cols, src_strd, dst_strd;
-    WORD32 i;
-
-    /* copy luma */
-    pu1_src = (UWORD8 *)pu1_y_src;
-    pu1_dst = (UWORD8 *)pu1_y_dst;
-
-    num_rows = ht;
-    num_cols = wd;
-
-    src_strd = src_y_strd;
-    dst_strd = dst_y_strd;
-
-    for(i = 0; i < num_rows; i++)
-    {
-        memcpy(pu1_dst, pu1_src, num_cols);
-        pu1_dst += dst_strd;
-        pu1_src += src_strd;
+        memcpy(pu1_uv_dst, pu1_uv_src, num_cols);
+        pu1_uv_dst += dst_uv_strd;
+        pu1_uv_src += src_uv_strd;
     }
     return;
 }
@@ -279,10 +257,10 @@ void ihevcd_fmt_conv_400_to_420p(UWORD8 *pu1_y_src,
                                  WORD32 dst_uv_strd)
 {
     ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
-    for(int i = 0; i < ht / 2; i++)
+    for(int i = 0; i < ALIGN2(ht) / 2; i++)
     {
-        memset(pu1_u_dst, 128, wd / 2);
-        memset(pu1_v_dst, 128, wd / 2);
+        memset(pu1_u_dst, 128, ALIGN2(wd) / 2);
+        memset(pu1_v_dst, 128, ALIGN2(wd) / 2);
         pu1_u_dst += dst_uv_strd;
         pu1_v_dst += dst_uv_strd;
     }
@@ -354,8 +332,8 @@ void ihevcd_fmt_conv_420sp_to_420sp_swap_uv(UWORD8 *pu1_y_src,
     pu1_src = (UWORD8 *)pu1_y_src;
     pu1_dst = (UWORD8 *)pu1_y_dst;
 
-    num_rows = ht;
-    num_cols = wd;
+    num_rows = ALIGN2(ht);
+    num_cols = ALIGN2(wd);
 
     src_strd = src_y_strd;
     dst_strd = dst_y_strd;
@@ -371,8 +349,8 @@ void ihevcd_fmt_conv_420sp_to_420sp_swap_uv(UWORD8 *pu1_y_src,
     pu1_src = (UWORD8 *)pu1_uv_src;
     pu1_dst = (UWORD8 *)pu1_uv_dst;
 
-    num_rows = ht >> 1;
-    num_cols = wd;
+    num_rows = ALIGN2(ht) >> 1;
+    num_cols = ALIGN2(wd);
 
     src_strd = src_uv_strd;
     dst_strd = dst_uv_strd;
@@ -466,21 +444,7 @@ void ihevcd_fmt_conv_420sp_to_420p(UWORD8 *pu1_y_src,
     if(0 == disable_luma_copy)
     {
         /* copy luma */
-        pu1_src = (UWORD8 *)pu1_y_src;
-        pu1_dst = (UWORD8 *)pu1_y_dst;
-
-        num_rows = ht;
-        num_cols = wd;
-
-        src_strd = src_y_strd;
-        dst_strd = dst_y_strd;
-
-        for(i = 0; i < num_rows; i++)
-        {
-            memcpy(pu1_dst, pu1_src, num_cols);
-            pu1_dst += dst_strd;
-            pu1_src += src_strd;
-        }
+        ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
     }
     /* de-interleave U and V and copy to destination */
     if(is_u_first)
@@ -495,8 +459,8 @@ void ihevcd_fmt_conv_420sp_to_420p(UWORD8 *pu1_y_src,
     }
 
 
-    num_rows = ht >> 1;
-    num_cols = wd >> 1;
+    num_rows = ALIGN2(ht) >> 1;
+    num_cols = ALIGN2(wd) >> 1;
 
     src_strd = src_uv_strd;
     dst_strd = dst_uv_strd;
@@ -583,9 +547,9 @@ void ihevcd_fmt_conv_444sp_to_444p(UWORD8 *pu1_y_src,
     UWORD8 *pu1_u_src = (UWORD8*)pu1_uv_src;
     UWORD8 *pu1_v_src = (UWORD8*)pu1_uv_src + 1;
 
-    for(WORD32 i = 0; i < ht; i++)
+    for(WORD32 i = 0; i < ALIGN2(ht); i++)
     {
-        for(WORD32 j = 0; j < wd; j++)
+        for(WORD32 j = 0; j < ALIGN2(wd); j++)
         {
             pu1_u_dst[j] = pu1_u_src[j * 2];
             pu1_v_dst[j] = pu1_v_src[j * 2];
@@ -612,9 +576,9 @@ void ihevcd_fmt_conv_444sp_to_420p(UWORD8 *pu1_y_src,
 {
     ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
 
-    for(WORD32 i = 0; i < ht; i += 2)
+    for(WORD32 i = 0; i < ALIGN2(ht); i += 2)
     {
-        for(WORD32 j = 0; j < wd; j += 2)
+        for(WORD32 j = 0; j < ALIGN2(wd); j += 2)
         {
             pu1_u_dst[j / 2] = pu1_uv_src[j * 2];
             pu1_v_dst[j / 2] = pu1_uv_src[j * 2 + 1];
@@ -646,9 +610,9 @@ void ihevcd_fmt_conv_422sp_to_422p(UWORD8 *pu1_y_src,
     pu1_u_src = (UWORD8 *)pu1_uv_src;
     pu1_v_src = (UWORD8 *)pu1_uv_src + 1;
 
-    for(i = 0; i < ht; i++)
+    for(i = 0; i < ALIGN2(ht); i++)
     {
-        for(j = 0; j < (wd >> 1); j++)
+        for(j = 0; j < (ALIGN2(wd) >> 1); j++)
         {
             pu1_u_dst[j] = pu1_u_src[j * 2];
             pu1_v_dst[j] = pu1_v_src[j * 2];
@@ -676,9 +640,9 @@ void ihevcd_fmt_conv_422sp_to_420p(UWORD8 *pu1_y_src,
 {
     ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
 
-    for(WORD32 i = 0; i < ht; i += 2)
+    for(WORD32 i = 0; i < ALIGN2(ht); i += 2)
     {
-        for(WORD32 j = 0; j < wd; j += 2)
+        for(WORD32 j = 0; j < ALIGN2(wd); j += 2)
         {
             pu1_u_dst[j / 2] = pu1_uv_src[j * 2];
             pu1_v_dst[j / 2] = pu1_uv_src[j * 2 + 1];
@@ -819,26 +783,26 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 }
             }
         }
-        pu1_y_dst_tmp  = pu1_y_dst  + cur_row * ps_codec->i4_disp_strd;
+        pu1_y_dst_tmp  = pu1_y_dst  + cur_row * ALIGN2(ps_codec->i4_disp_strd);
         if(IV_YUV_444P == ps_codec->e_chroma_fmt)
         {
-            pu1_u_dst_tmp = pu1_u_dst + cur_row * ps_codec->i4_disp_strd;
-            pu1_v_dst_tmp = pu1_v_dst + cur_row * ps_codec->i4_disp_strd;
+            pu1_u_dst_tmp = pu1_u_dst + cur_row * ALIGN2(ps_codec->i4_disp_strd);
+            pu1_v_dst_tmp = pu1_v_dst + cur_row * ALIGN2(ps_codec->i4_disp_strd);
         }
         else if(IV_YUV_422P == ps_codec->e_chroma_fmt)
         {
-            pu1_u_dst_tmp = pu1_u_dst + cur_row * ps_codec->i4_disp_strd / 2;
-            pu1_v_dst_tmp = pu1_v_dst + cur_row * ps_codec->i4_disp_strd / 2;
+            pu1_u_dst_tmp = pu1_u_dst + cur_row * (ALIGN2(ps_codec->i4_disp_strd) / 2);
+            pu1_v_dst_tmp = pu1_v_dst + cur_row * (ALIGN2(ps_codec->i4_disp_strd) / 2);
         }
         else if(IV_YUV_420P == ps_codec->e_chroma_fmt)
         {
-            pu1_u_dst_tmp = pu1_u_dst + (cur_row / 2) * ps_codec->i4_disp_strd / 2;
-            pu1_v_dst_tmp = pu1_v_dst + (cur_row / 2) * ps_codec->i4_disp_strd / 2;
+            pu1_u_dst_tmp = pu1_u_dst + (cur_row / 2) * (ALIGN2(ps_codec->i4_disp_strd) / 2);
+            pu1_v_dst_tmp = pu1_v_dst + (cur_row / 2) * (ALIGN2(ps_codec->i4_disp_strd) / 2);
         }
         else if(IV_YUV_420SP_UV == ps_codec->e_chroma_fmt
                         || IV_YUV_420SP_VU == ps_codec->e_chroma_fmt)
         {
-            pu1_uv_dst_tmp = pu1_u_dst + (cur_row / 2) * ps_codec->i4_disp_strd;
+            pu1_uv_dst_tmp = pu1_u_dst + (cur_row / 2) * ALIGN2(ps_codec->i4_disp_strd);
         }
 
         /* In case of multi threaded implementation, format conversion might be called
@@ -905,8 +869,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 fmt_conv_fptr(pu1_y_src, pu1_uv_src,
                               pu1_y_dst_tmp, pu1_uv_dst_tmp,
                               ps_codec->i4_disp_wd, num_rows,
-                              ps_codec->i4_strd, ps_codec->i4_strd,
-                              ps_codec->i4_disp_strd, ps_codec->i4_disp_strd);
+                              ALIGN2(ps_codec->i4_strd), ALIGN2(ps_codec->i4_strd),
+                              ALIGN2(ps_codec->i4_disp_strd), ALIGN2(ps_codec->i4_disp_strd));
             }
         }
         else if(IV_GRAY == ps_codec->e_chroma_fmt)
@@ -914,8 +878,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
             ihevcd_fmt_conv_luma_copy(pu1_y_src,
                                        pu1_y_dst_tmp,
                                        ps_codec->i4_disp_wd, num_rows,
-                                       ps_codec->i4_strd,
-                                       ps_codec->i4_disp_strd);
+                                       ALIGN2(ps_codec->i4_strd),
+                                       ALIGN2(ps_codec->i4_disp_strd));
         }
         else if(IV_YUV_444P == ps_codec->e_chroma_fmt)
         {
@@ -925,8 +889,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                                 pu1_y_src, pu1_uv_src,
                                 pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                 ps_codec->i4_disp_wd, num_rows,
-                                ps_codec->i4_strd, src_chroma_row_stride,
-                                ps_codec->i4_disp_strd, ps_codec->i4_disp_strd);
+                                ALIGN2(ps_codec->i4_strd), ALIGN2(src_chroma_row_stride),
+                                ALIGN2(ps_codec->i4_disp_strd), ALIGN2(ps_codec->i4_disp_strd));
             }
         }
         else if(IV_YUV_422P == ps_codec->e_chroma_fmt)
@@ -936,8 +900,9 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 ihevcd_fmt_conv_422sp_to_422p(pu1_y_src, pu1_uv_src,
                                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                               ps_codec->i4_disp_wd, num_rows,
-                                              ps_codec->i4_strd, ps_codec->i4_strd,
-                                              ps_codec->i4_disp_strd, (ps_codec->i4_disp_strd / 2));
+                                              ALIGN2(ps_codec->i4_strd), ALIGN2(ps_codec->i4_strd),
+                                              ALIGN2(ps_codec->i4_disp_strd),
+                                              (ALIGN2(ps_codec->i4_disp_strd) / 2));
             }
         }
         else if(IV_YUV_420P == ps_codec->e_chroma_fmt)
@@ -947,8 +912,9 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 ihevcd_fmt_conv_400_to_420p(pu1_y_src,
                                             pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                             ps_codec->i4_disp_wd, num_rows,
-                                            ps_codec->i4_strd,
-                                            ps_codec->i4_disp_strd, (ps_codec->i4_disp_strd / 2));
+                                            ALIGN2(ps_codec->i4_strd),
+                                            ALIGN2(ps_codec->i4_disp_strd),
+                                            (ALIGN2(ps_codec->i4_disp_strd) / 2));
             }
             else if(ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV420)
             {
@@ -966,9 +932,9 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 {
                     // copy luma
                     WORD32 i;
-                    WORD32 num_cols = ps_codec->i4_disp_wd;
+                    WORD32 num_cols = ALIGN2(ps_codec->i4_disp_wd);
 
-                    for(i = 0; i < num_rows; i++)
+                    for(i = 0; i < ALIGN2(num_rows); i++)
                     {
                         memcpy(pu1_y_dst_tmp, pu1_y_src, num_cols);
                         pu1_y_dst_tmp += ps_codec->i4_disp_strd;
@@ -980,8 +946,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 fmt_conv_fptr(pu1_y_src, pu1_uv_src,
                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                               ps_codec->i4_disp_wd, num_rows,
-                              ps_codec->i4_strd, ps_codec->i4_strd,
-                              ps_codec->i4_disp_strd, (ps_codec->i4_disp_strd / 2),
+                              ALIGN2(ps_codec->i4_strd), ALIGN2(ps_codec->i4_strd),
+                              ALIGN2(ps_codec->i4_disp_strd), (ALIGN2(ps_codec->i4_disp_strd) / 2),
                               is_u_first,
                               disable_luma_copy);
             }
@@ -990,16 +956,20 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 ihevcd_fmt_conv_444sp_to_420p(pu1_y_src, pu1_uv_src,
                                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                               ps_codec->i4_disp_wd, num_rows,
-                                              ps_codec->i4_strd, src_chroma_row_stride,
-                                              ps_codec->i4_disp_strd, ps_codec->i4_disp_strd / 2);
+                                              ALIGN2(ps_codec->i4_strd),
+                                              ALIGN2(src_chroma_row_stride),
+                                              ALIGN2(ps_codec->i4_disp_strd),
+                                              (ALIGN2(ps_codec->i4_disp_strd) / 2));
             }
             else if(ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV422)
             {
                 ihevcd_fmt_conv_422sp_to_420p(pu1_y_src, pu1_uv_src,
                                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                               ps_codec->i4_disp_wd, num_rows,
-                                              ps_codec->i4_strd, src_chroma_row_stride,
-                                              ps_codec->i4_disp_strd, ps_codec->i4_disp_strd / 2);
+                                              ALIGN2(ps_codec->i4_strd),
+                                              ALIGN2(src_chroma_row_stride),
+                                              ALIGN2(ps_codec->i4_disp_strd),
+                                              (ALIGN2(ps_codec->i4_disp_strd) / 2));
             }
         }
     }

--- a/decoder/ihevcd_utils.c
+++ b/decoder/ihevcd_utils.c
@@ -806,36 +806,39 @@ IHEVCD_ERROR_T ihevcd_check_out_buf_size(codec_t *ps_codec)
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
         u4_min_num_out_bufs = MIN_OUT_BUFS_GRAY;
 
+    WORD32 aligned_wd = ALIGN2(wd);
+    WORD32 aligned_ht = ALIGN2(ht);
     if(ps_codec->e_chroma_fmt == IV_YUV_420P)
     {
-        au4_min_out_buf_size[0] = (wd * ht);
-        au4_min_out_buf_size[1] = (wd * ht) >> 2;
-        au4_min_out_buf_size[2] = (wd * ht) >> 2;
+        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        au4_min_out_buf_size[2] = (aligned_wd >> 1) * (aligned_ht >> 1);
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_444P)
     {
-        au4_min_out_buf_size[0] = (wd * ht);
-        au4_min_out_buf_size[1] = (wd * ht);
-        au4_min_out_buf_size[2] = (wd * ht);
+        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[1] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[2] = (aligned_wd * aligned_ht);
     }
     else if((ps_codec->e_chroma_fmt == IV_YUV_420SP_UV)
                     || (ps_codec->e_chroma_fmt == IV_YUV_420SP_VU))
     {
-        au4_min_out_buf_size[0] = (wd * ht);
-        au4_min_out_buf_size[1] = (wd * ht) >> 1;
+        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        au4_min_out_buf_size[1] <<= 1;
         au4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
     {
-        au4_min_out_buf_size[0] = (wd * ht);
+        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
         au4_min_out_buf_size[1] = 0;
         au4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
     {
-        au4_min_out_buf_size[0] = (wd * ht);
-        au4_min_out_buf_size[1] = (wd * ht) >> 1;
-        au4_min_out_buf_size[2] = (wd * ht) >> 1;
+        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[1] = (aligned_wd >> 1) * aligned_ht;
+        au4_min_out_buf_size[2] = (aligned_wd >> 1) * aligned_ht;
     }
 
 


### PR DESCRIPTION
Decoding streams with odd resolutions previously caused integer truncation during right-shift or division operations, leading to incorrect buffer size and stride calculations.
This is fixed by applying the ALIGN2 macro to width and height across buffer metrics, dimension queries, and outargs to safely pad boundaries.

Test: ./hevcdec

Change-Id: I5c432aa63b0975b76baa5e59a816278087b65215