### PR TITLE
Updates to odd dimension support.

### DIFF
--- a/decoder/ihevcd_api.c
+++ b/decoder/ihevcd_api.c
@@ -2635,6 +2635,7 @@ WORD32 ihevcd_get_status(iv_obj_t *ps_codec_obj,
     WORD32 i;
     codec_t *ps_codec;
     WORD32 wd, ht;
+    WORD32 aligned_wd, aligned_ht;
     ivd_ctl_getstatus_op_t *ps_ctl_op = (ivd_ctl_getstatus_op_t *)pv_api_op;
 
     UNUSED(pv_api_ip);
@@ -2713,39 +2714,38 @@ WORD32 ihevcd_get_status(iv_obj_t *ps_codec_obj,
     }
 
     /*!*/
-    WORD32 aligned_wd = ALIGN2(wd);
-    WORD32 aligned_ht = ALIGN2(ht);
+    aligned_wd = ALIGN2(wd);
+    aligned_ht = ALIGN2(ht);
     if(ps_codec->e_chroma_fmt == IV_YUV_420P)
     {
         ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
-        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 2;
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht) >> 2;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_444P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht);
     }
     else if((ps_codec->e_chroma_fmt == IV_YUV_420SP_UV)
                     || (ps_codec->e_chroma_fmt == IV_YUV_420SP_VU))
     {
         ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
-        ps_ctl_op->u4_min_out_buf_size[1] <<= 1;
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 1;
         ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
         ps_ctl_op->u4_min_out_buf_size[1] = 0;
         ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
     {
         ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * aligned_ht;
-        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * aligned_ht;
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 1;
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht) >> 1;
     }
     ps_ctl_op->u4_pic_ht = ht;
     ps_ctl_op->u4_pic_wd = wd;
@@ -2798,6 +2798,7 @@ WORD32 ihevcd_get_buf_info(iv_obj_t *ps_codec_obj,
     codec_t *ps_codec;
     UWORD32 i = 0;
     WORD32 wd, ht;
+    WORD32 aligned_wd, aligned_ht;
     ivd_ctl_getbufinfo_op_t *ps_ctl_op =
                     (ivd_ctl_getbufinfo_op_t *)pv_api_op;
 
@@ -2904,38 +2905,38 @@ WORD32 ihevcd_get_buf_info(iv_obj_t *ps_codec_obj,
     }
 
     /*!*/
-    WORD32 aligned_wd = ALIGN2(wd);
-    WORD32 aligned_ht = ALIGN2(ht);
+    aligned_wd = ALIGN2(wd);
+    aligned_ht = ALIGN2(ht);
     if(ps_codec->e_chroma_fmt == IV_YUV_420P)
     {
         ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
-        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 2;
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht) >> 2;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_444P)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht);
+        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[1] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[2] = (wd * ht);
     }
     else if((ps_codec->e_chroma_fmt == IV_YUV_420SP_UV)
                     || (ps_codec->e_chroma_fmt == IV_YUV_420SP_VU))
     {
         ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
-        ps_ctl_op->u4_min_out_buf_size[1] <<= 1;
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 1;
         ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
     {
-        ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = ps_ctl_op->u4_min_out_buf_size[2] = 0;
+        ps_ctl_op->u4_min_out_buf_size[0] = (wd * ht);
+        ps_ctl_op->u4_min_out_buf_size[1] =
+                        ps_ctl_op->u4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
     {
         ps_ctl_op->u4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd >> 1) * aligned_ht;
-        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd >> 1) * aligned_ht;
+        ps_ctl_op->u4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 1;
+        ps_ctl_op->u4_min_out_buf_size[2] = (aligned_wd * aligned_ht) >> 1;
     }
     ps_codec->i4_num_disp_bufs = ps_ctl_op->u4_num_disp_bufs;
 
@@ -3027,6 +3028,17 @@ WORD32 ihevcd_set_params(iv_obj_t *ps_codec_obj,
             s_ctl_dynparams_op->u4_error_code |= IHEVCD_INVALID_DISP_STRD;
             ret = IV_FAIL;
         }
+    }
+
+    // output stride needs to be even for all formats other than 400 and 444
+    if(ps_codec->e_chroma_fmt != IV_GRAY && ps_codec->e_chroma_fmt != IV_YUV_444P)
+    {
+	if (strd & 1)
+	{
+            s_ctl_dynparams_op->u4_error_code |= (1 << IVD_UNSUPPORTEDPARAM);
+            s_ctl_dynparams_op->u4_error_code |= IHEVCD_INVALID_DISP_STRD;
+            ret = IV_FAIL;
+	}
     }
 
     ps_codec->i4_disp_strd = strd;
@@ -3306,9 +3318,9 @@ WORD32 ihevcd_get_frame_dimensions(iv_obj_t *ps_codec_obj,
                     >> 1);
     ps_op->u4_disp_ht[1] = ps_op->u4_disp_ht[2] = ((ps_op->u4_disp_ht[0] + 1)
                     >> 1);
-    ps_op->u4_buffer_wd[1] = ps_op->u4_buffer_wd[2] = ((ps_op->u4_buffer_wd[0] + 1)
+    ps_op->u4_buffer_wd[1] = ps_op->u4_buffer_wd[2] = (ps_op->u4_buffer_wd[0]
                     >> 1);
-    ps_op->u4_buffer_ht[1] = ps_op->u4_buffer_ht[2] = ((ps_op->u4_buffer_ht[0] + 1)
+    ps_op->u4_buffer_ht[1] = ps_op->u4_buffer_ht[2] = (ps_op->u4_buffer_ht[0]
                     >> 1);
     ps_op->u4_x_offset[1] = ps_op->u4_x_offset[2] = (ps_op->u4_x_offset[0]
                     >> 1);

--- a/decoder/ihevcd_decode.c
+++ b/decoder/ihevcd_decode.c
@@ -325,13 +325,14 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
                             ps_dec_ip->s_out_buffer.pu1_bufs[1];
             ps_dec_op->s_disp_frm_buf.pv_v_buf =
                             ps_dec_ip->s_out_buffer.pu1_bufs[2];
-            ps_dec_op->s_disp_frm_buf.u4_y_strd = ALIGN2(ps_codec->i4_disp_strd);
+            ps_dec_op->s_disp_frm_buf.u4_y_strd = ps_codec->i4_disp_strd;
         }
 
         if((IV_YUV_420SP_VU == ps_codec->e_chroma_fmt)
                         || (IV_YUV_420SP_UV == ps_codec->e_chroma_fmt))
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd);
+            ps_dec_op->s_disp_frm_buf.u4_u_strd =
+                            ps_dec_op->s_disp_frm_buf.u4_y_strd;
             ps_dec_op->s_disp_frm_buf.u4_v_strd = 0;
             ps_dec_op->s_disp_frm_buf.u4_u_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd);
             ps_dec_op->s_disp_frm_buf.u4_v_wd = 0;
@@ -340,8 +341,10 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
         }
         else if(IV_YUV_420P == ps_codec->e_chroma_fmt)
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_strd =
+                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_strd =
+                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
             ps_dec_op->s_disp_frm_buf.u4_u_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
             ps_dec_op->s_disp_frm_buf.u4_v_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
             ps_dec_op->s_disp_frm_buf.u4_u_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht) / 2;
@@ -349,8 +352,8 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
         }
         else if(IV_YUV_444P == ps_codec->e_chroma_fmt)
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd);
-            ps_dec_op->s_disp_frm_buf.u4_v_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd);
+            ps_dec_op->s_disp_frm_buf.u4_u_strd = ps_dec_op->s_disp_frm_buf.u4_y_strd;
+            ps_dec_op->s_disp_frm_buf.u4_v_strd = ps_dec_op->s_disp_frm_buf.u4_y_strd;
             ps_dec_op->s_disp_frm_buf.u4_u_wd = ps_dec_op->s_disp_frm_buf.u4_y_wd;
             ps_dec_op->s_disp_frm_buf.u4_v_wd = ps_dec_op->s_disp_frm_buf.u4_y_wd;
             ps_dec_op->s_disp_frm_buf.u4_u_ht = ps_dec_op->s_disp_frm_buf.u4_y_ht;
@@ -367,8 +370,10 @@ static void ihevcd_fill_outargs(codec_t *ps_codec,
         }
         else if(IV_YUV_422P == ps_codec->e_chroma_fmt)
         {
-            ps_dec_op->s_disp_frm_buf.u4_u_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
-            ps_dec_op->s_disp_frm_buf.u4_v_strd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_strd) / 2;
+            ps_dec_op->s_disp_frm_buf.u4_u_strd =
+                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
+            ps_dec_op->s_disp_frm_buf.u4_v_strd =
+                            ps_dec_op->s_disp_frm_buf.u4_y_strd / 2;
             ps_dec_op->s_disp_frm_buf.u4_u_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
             ps_dec_op->s_disp_frm_buf.u4_v_wd = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_wd) / 2;
             ps_dec_op->s_disp_frm_buf.u4_u_ht = ALIGN2(ps_dec_op->s_disp_frm_buf.u4_y_ht);

--- a/decoder/ihevcd_fmt_conv.c
+++ b/decoder/ihevcd_fmt_conv.c
@@ -70,6 +70,105 @@
 /**
 *******************************************************************************
 *
+* @brief Function used from copying a 420SP buffer
+*
+* @par   Description
+* Function used from copying a 420SP buffer
+*
+* @param[in] pu1_y_src
+*   Input Y pointer
+*
+* @param[in] pu1_uv_src
+*   Input UV pointer (UV is interleaved either in UV or VU format)
+*
+* @param[in] pu1_y_dst
+*   Output Y pointer
+*
+* @param[in] pu1_uv_dst
+*   Output UV pointer (UV is interleaved in the same format as that of input)
+*
+* @param[in] wd
+*   Width
+*
+* @param[in] ht
+*   Height
+*
+* @param[in] src_y_strd
+*   Input Y Stride
+*
+* @param[in] src_uv_strd
+*   Input UV stride
+*
+* @param[in] dst_y_strd
+*   Output Y stride
+*
+* @param[in] dst_uv_strd
+*   Output UV stride
+*
+* @returns None
+*
+* @remarks In case there is a need to perform partial frame copy then
+* by passion appropriate source and destination pointers and appropriate
+* values for wd and ht it can be done
+*
+*******************************************************************************
+*/
+
+void ihevcd_fmt_conv_420sp_to_420sp(UWORD8 *pu1_y_src,
+                                    UWORD8 *pu1_uv_src,
+                                    UWORD8 *pu1_y_dst,
+                                    UWORD8 *pu1_uv_dst,
+                                    WORD32 wd,
+                                    WORD32 ht,
+                                    WORD32 src_y_strd,
+                                    WORD32 src_uv_strd,
+                                    WORD32 dst_y_strd,
+                                    WORD32 dst_uv_strd)
+{
+    UWORD8 *pu1_src, *pu1_dst;
+    WORD32 num_rows, num_cols, src_strd, dst_strd;
+    WORD32 i;
+
+    /* copy luma */
+    pu1_src = (UWORD8 *)pu1_y_src;
+    pu1_dst = (UWORD8 *)pu1_y_dst;
+
+    num_rows = ALIGN2(ht);
+    num_cols = ALIGN2(wd);
+
+    src_strd = src_y_strd;
+    dst_strd = dst_y_strd;
+
+    for(i = 0; i < num_rows; i++)
+    {
+        memcpy(pu1_dst, pu1_src, num_cols);
+        pu1_dst += dst_strd;
+        pu1_src += src_strd;
+    }
+
+    /* copy U and V */
+    pu1_src = (UWORD8 *)pu1_uv_src;
+    pu1_dst = (UWORD8 *)pu1_uv_dst;
+
+    num_rows = ALIGN2(ht) >> 1;
+    num_cols = ALIGN2(wd);
+
+    src_strd = src_uv_strd;
+    dst_strd = dst_uv_strd;
+
+    for(i = 0; i < num_rows; i++)
+    {
+        memcpy(pu1_dst, pu1_src, num_cols);
+        pu1_dst += dst_strd;
+        pu1_src += src_strd;
+    }
+    return;
+}
+
+
+/**
+*******************************************************************************
+*
 * @brief Function used from copying a 400 buffer
 *
 * @par   Description
@@ -128,83 +227,6 @@ void ihevcd_fmt_conv_luma_copy(UWORD8 *pu1_y_src,
         memcpy(pu1_dst, pu1_src, num_cols);
         pu1_dst += dst_strd;
         pu1_src += src_strd;
-    }
-    return;
-}
-
-/**
-*******************************************************************************
-*
-* @brief Function used from copying a 420SP buffer
-*
-* @par   Description
-* Function used from copying a 420SP buffer
-*
-* @param[in] pu1_y_src
-*   Input Y pointer
-*
-* @param[in] pu1_uv_src
-*   Input UV pointer (UV is interleaved either in UV or VU format)
-*
-* @param[in] pu1_y_dst
-*   Output Y pointer
-*
-* @param[in] pu1_uv_dst
-*   Output UV pointer (UV is interleaved in the same format as that of input)
-*
-* @param[in] wd
-*   Width
-*
-* @param[in] ht
-*   Height
-*
-* @param[in] src_y_strd
-*   Input Y Stride
-*
-* @param[in] src_uv_strd
-*   Input UV stride
-*
-* @param[in] dst_y_strd
-*   Output Y stride
-*
-* @param[in] dst_uv_strd
-*   Output UV stride
-*
-* @returns None
-*
-* @remarks In case there is a need to perform partial frame copy then
-* by passion appropriate source and destination pointers and appropriate
-* values for wd and ht it can be done
-*
-*******************************************************************************
-*/
-
-void ihevcd_fmt_conv_420sp_to_420sp(UWORD8 *pu1_y_src,
-                                    UWORD8 *pu1_uv_src,
-                                    UWORD8 *pu1_y_dst,
-                                    UWORD8 *pu1_uv_dst,
-                                    WORD32 wd,
-                                    WORD32 ht,
-                                    WORD32 src_y_strd,
-                                    WORD32 src_uv_strd,
-                                    WORD32 dst_y_strd,
-                                    WORD32 dst_uv_strd)
-{
-    WORD32 num_rows, num_cols;
-    WORD32 i;
-
-    /* copy luma */
-    ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
-
-    /* copy U and V */
-    num_rows = (ht + 1) >> 1;
-    num_cols = ALIGN2(wd);
-
-    for(i = 0; i < num_rows; i++)
-    {
-        memcpy(pu1_uv_dst, pu1_uv_src, num_cols);
-        pu1_uv_dst += dst_uv_strd;
-        pu1_uv_src += src_uv_strd;
     }
     return;
 }
@@ -444,7 +466,21 @@ void ihevcd_fmt_conv_420sp_to_420p(UWORD8 *pu1_y_src,
     if(0 == disable_luma_copy)
     {
         /* copy luma */
-        ihevcd_fmt_conv_luma_copy(pu1_y_src, pu1_y_dst, wd, ht, src_y_strd, dst_y_strd);
+        pu1_src = (UWORD8 *)pu1_y_src;
+        pu1_dst = (UWORD8 *)pu1_y_dst;
+
+        num_rows = ALIGN2(ht);
+        num_cols = ALIGN2(wd);
+
+        src_strd = src_y_strd;
+        dst_strd = dst_y_strd;
+
+        for(i = 0; i < num_rows; i++)
+        {
+            memcpy(pu1_dst, pu1_src, num_cols);
+            pu1_dst += dst_strd;
+            pu1_src += src_strd;
+        }
     }
     /* de-interleave U and V and copy to destination */
     if(is_u_first)
@@ -547,9 +583,9 @@ void ihevcd_fmt_conv_444sp_to_444p(UWORD8 *pu1_y_src,
     UWORD8 *pu1_u_src = (UWORD8*)pu1_uv_src;
     UWORD8 *pu1_v_src = (UWORD8*)pu1_uv_src + 1;
 
-    for(WORD32 i = 0; i < ALIGN2(ht); i++)
+    for(WORD32 i = 0; i < ht; i++)
     {
-        for(WORD32 j = 0; j < ALIGN2(wd); j++)
+        for(WORD32 j = 0; j < wd; j++)
         {
             pu1_u_dst[j] = pu1_u_src[j * 2];
             pu1_v_dst[j] = pu1_v_src[j * 2];
@@ -783,26 +819,26 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 }
             }
         }
-        pu1_y_dst_tmp  = pu1_y_dst  + cur_row * ALIGN2(ps_codec->i4_disp_strd);
+        pu1_y_dst_tmp  = pu1_y_dst  + cur_row * ps_codec->i4_disp_strd;
         if(IV_YUV_444P == ps_codec->e_chroma_fmt)
         {
-            pu1_u_dst_tmp = pu1_u_dst + cur_row * ALIGN2(ps_codec->i4_disp_strd);
-            pu1_v_dst_tmp = pu1_v_dst + cur_row * ALIGN2(ps_codec->i4_disp_strd);
+            pu1_u_dst_tmp = pu1_u_dst + cur_row * ps_codec->i4_disp_strd;
+            pu1_v_dst_tmp = pu1_v_dst + cur_row * ps_codec->i4_disp_strd;
         }
         else if(IV_YUV_422P == ps_codec->e_chroma_fmt)
         {
-            pu1_u_dst_tmp = pu1_u_dst + cur_row * (ALIGN2(ps_codec->i4_disp_strd) / 2);
-            pu1_v_dst_tmp = pu1_v_dst + cur_row * (ALIGN2(ps_codec->i4_disp_strd) / 2);
+            pu1_u_dst_tmp = pu1_u_dst + cur_row * ps_codec->i4_disp_strd / 2;
+            pu1_v_dst_tmp = pu1_v_dst + cur_row * ps_codec->i4_disp_strd / 2;
         }
         else if(IV_YUV_420P == ps_codec->e_chroma_fmt)
         {
-            pu1_u_dst_tmp = pu1_u_dst + (cur_row / 2) * (ALIGN2(ps_codec->i4_disp_strd) / 2);
-            pu1_v_dst_tmp = pu1_v_dst + (cur_row / 2) * (ALIGN2(ps_codec->i4_disp_strd) / 2);
+            pu1_u_dst_tmp = pu1_u_dst + (cur_row / 2) * ps_codec->i4_disp_strd / 2;
+            pu1_v_dst_tmp = pu1_v_dst + (cur_row / 2) * ps_codec->i4_disp_strd / 2;
         }
         else if(IV_YUV_420SP_UV == ps_codec->e_chroma_fmt
                         || IV_YUV_420SP_VU == ps_codec->e_chroma_fmt)
         {
-            pu1_uv_dst_tmp = pu1_u_dst + (cur_row / 2) * ALIGN2(ps_codec->i4_disp_strd);
+            pu1_uv_dst_tmp = pu1_u_dst + (cur_row / 2) * ps_codec->i4_disp_strd;
         }
 
         /* In case of multi threaded implementation, format conversion might be called
@@ -869,8 +905,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 fmt_conv_fptr(pu1_y_src, pu1_uv_src,
                               pu1_y_dst_tmp, pu1_uv_dst_tmp,
                               ps_codec->i4_disp_wd, num_rows,
-                              ALIGN2(ps_codec->i4_strd), ALIGN2(ps_codec->i4_strd),
-                              ALIGN2(ps_codec->i4_disp_strd), ALIGN2(ps_codec->i4_disp_strd));
+                              ps_codec->i4_strd, ps_codec->i4_strd,
+                              ps_codec->i4_disp_strd, ps_codec->i4_disp_strd);
             }
         }
         else if(IV_GRAY == ps_codec->e_chroma_fmt)
@@ -878,8 +914,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
             ihevcd_fmt_conv_luma_copy(pu1_y_src,
                                        pu1_y_dst_tmp,
                                        ps_codec->i4_disp_wd, num_rows,
-                                       ALIGN2(ps_codec->i4_strd),
-                                       ALIGN2(ps_codec->i4_disp_strd));
+                                       ps_codec->i4_strd,
+                                       ps_codec->i4_disp_strd);
         }
         else if(IV_YUV_444P == ps_codec->e_chroma_fmt)
         {
@@ -889,8 +925,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                                 pu1_y_src, pu1_uv_src,
                                 pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                 ps_codec->i4_disp_wd, num_rows,
-                                ALIGN2(ps_codec->i4_strd), ALIGN2(src_chroma_row_stride),
-                                ALIGN2(ps_codec->i4_disp_strd), ALIGN2(ps_codec->i4_disp_strd));
+                                ps_codec->i4_strd, src_chroma_row_stride,
+                                ps_codec->i4_disp_strd, ps_codec->i4_disp_strd);
             }
         }
         else if(IV_YUV_422P == ps_codec->e_chroma_fmt)
@@ -900,9 +936,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 ihevcd_fmt_conv_422sp_to_422p(pu1_y_src, pu1_uv_src,
                                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                               ps_codec->i4_disp_wd, num_rows,
-                                              ALIGN2(ps_codec->i4_strd), ALIGN2(ps_codec->i4_strd),
-                                              ALIGN2(ps_codec->i4_disp_strd),
-                                              (ALIGN2(ps_codec->i4_disp_strd) / 2));
+                                              ps_codec->i4_strd, ps_codec->i4_strd,
+                                              ps_codec->i4_disp_strd, (ps_codec->i4_disp_strd / 2));
             }
         }
         else if(IV_YUV_420P == ps_codec->e_chroma_fmt)
@@ -912,9 +947,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 ihevcd_fmt_conv_400_to_420p(pu1_y_src,
                                             pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                             ps_codec->i4_disp_wd, num_rows,
-                                            ALIGN2(ps_codec->i4_strd),
-                                            ALIGN2(ps_codec->i4_disp_strd),
-                                            (ALIGN2(ps_codec->i4_disp_strd) / 2));
+                                            ps_codec->i4_strd,
+                                            ps_codec->i4_disp_strd, (ps_codec->i4_disp_strd / 2));
             }
             else if(ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV420)
             {
@@ -932,9 +966,9 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 {
                     // copy luma
                     WORD32 i;
-                    WORD32 num_cols = ALIGN2(ps_codec->i4_disp_wd);
+                    WORD32 num_cols = ps_codec->i4_disp_wd;
 
-                    for(i = 0; i < ALIGN2(num_rows); i++)
+                    for(i = 0; i < num_rows; i++)
                     {
                         memcpy(pu1_y_dst_tmp, pu1_y_src, num_cols);
                         pu1_y_dst_tmp += ps_codec->i4_disp_strd;
@@ -946,8 +980,8 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 fmt_conv_fptr(pu1_y_src, pu1_uv_src,
                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                               ps_codec->i4_disp_wd, num_rows,
-                              ALIGN2(ps_codec->i4_strd), ALIGN2(ps_codec->i4_strd),
-                              ALIGN2(ps_codec->i4_disp_strd), (ALIGN2(ps_codec->i4_disp_strd) / 2),
+                              ps_codec->i4_strd, ps_codec->i4_strd,
+                              ps_codec->i4_disp_strd, (ps_codec->i4_disp_strd / 2),
                               is_u_first,
                               disable_luma_copy);
             }
@@ -956,20 +990,16 @@ IHEVCD_ERROR_T ihevcd_fmt_conv(codec_t *ps_codec,
                 ihevcd_fmt_conv_444sp_to_420p(pu1_y_src, pu1_uv_src,
                                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                               ps_codec->i4_disp_wd, num_rows,
-                                              ALIGN2(ps_codec->i4_strd),
-                                              ALIGN2(src_chroma_row_stride),
-                                              ALIGN2(ps_codec->i4_disp_strd),
-                                              (ALIGN2(ps_codec->i4_disp_strd) / 2));
+                                              ps_codec->i4_strd, src_chroma_row_stride,
+                                              ps_codec->i4_disp_strd, ps_codec->i4_disp_strd / 2);
             }
             else if(ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV422)
             {
                 ihevcd_fmt_conv_422sp_to_420p(pu1_y_src, pu1_uv_src,
                                               pu1_y_dst_tmp, pu1_u_dst_tmp, pu1_v_dst_tmp,
                                               ps_codec->i4_disp_wd, num_rows,
-                                              ALIGN2(ps_codec->i4_strd),
-                                              ALIGN2(src_chroma_row_stride),
-                                              ALIGN2(ps_codec->i4_disp_strd),
-                                              (ALIGN2(ps_codec->i4_disp_strd) / 2));
+                                              ps_codec->i4_strd, src_chroma_row_stride,
+                                              ps_codec->i4_disp_strd, ps_codec->i4_disp_strd / 2);
             }
         }
     }

--- a/decoder/ihevcd_utils.c
+++ b/decoder/ihevcd_utils.c
@@ -779,6 +779,7 @@ IHEVCD_ERROR_T ihevcd_check_out_buf_size(codec_t *ps_codec)
     UWORD32 au4_min_out_buf_size[IVD_VIDDEC_MAX_IO_BUFFERS];
     UWORD32 u4_min_num_out_bufs = 0, i;
     UWORD32 wd, ht;
+    UWORD32 aligned_wd, aligned_ht;
 
     if(0 == ps_codec->i4_share_disp_buf)
     {
@@ -806,39 +807,38 @@ IHEVCD_ERROR_T ihevcd_check_out_buf_size(codec_t *ps_codec)
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
         u4_min_num_out_bufs = MIN_OUT_BUFS_GRAY;
 
-    WORD32 aligned_wd = ALIGN2(wd);
-    WORD32 aligned_ht = ALIGN2(ht);
+    aligned_wd = ALIGN2(wd);
+    aligned_ht = ALIGN2(ht);
     if(ps_codec->e_chroma_fmt == IV_YUV_420P)
     {
         au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        au4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
-        au4_min_out_buf_size[2] = (aligned_wd >> 1) * (aligned_ht >> 1);
+        au4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 2;
+        au4_min_out_buf_size[2] = (aligned_wd * aligned_ht) >> 2;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_444P)
     {
-        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        au4_min_out_buf_size[1] = (aligned_wd * aligned_ht);
-        au4_min_out_buf_size[2] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[0] = (wd * ht);
+        au4_min_out_buf_size[1] = (wd * ht);
+        au4_min_out_buf_size[2] = (wd * ht);
     }
     else if((ps_codec->e_chroma_fmt == IV_YUV_420SP_UV)
                     || (ps_codec->e_chroma_fmt == IV_YUV_420SP_VU))
     {
         au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        au4_min_out_buf_size[1] = (aligned_wd >> 1) * (aligned_ht >> 1);
-        au4_min_out_buf_size[1] <<= 1;
+        au4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 1;
         au4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_GRAY)
     {
-        au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
+        au4_min_out_buf_size[0] = (wd * ht);
         au4_min_out_buf_size[1] = 0;
         au4_min_out_buf_size[2] = 0;
     }
     else if(ps_codec->e_chroma_fmt == IV_YUV_422P)
     {
         au4_min_out_buf_size[0] = (aligned_wd * aligned_ht);
-        au4_min_out_buf_size[1] = (aligned_wd >> 1) * aligned_ht;
-        au4_min_out_buf_size[2] = (aligned_wd >> 1) * aligned_ht;
+        au4_min_out_buf_size[1] = (aligned_wd * aligned_ht) >> 1;
+        au4_min_out_buf_size[2] = (aligned_wd * aligned_ht) >> 1;
     }
 
 


### PR DESCRIPTION
Reverted some of the unnecessary changes from commit: f6ef16b0f9f74f5d15843ca336c098c93b18aac6

- Restored the format conversion structure prior to f6ef16b0f9f74f5d15843ca336c098c93b18aac6
- No need to handle odd stride for 420 and 422 output.
- Dimensions for output format 444 and 400 format can be odd

Tested with few YUV444 and YUV400 odd dimension clips

To generate:
$ ffmpeg -f lavfi -i testsrc=s=511x511 -c:v libx265 -pix_fmt yuv444p -t 1 -tag:v hvc1 y444_511x511.hevc $ ffmpeg -f lavfi -i testsrc=s=511x511 -c:v libx265 -pix_fmt gray -t 1 -tag:v hvc1 y400_511x511.hevc

To decode using hevcdec for YUV420 output format
$ hevcdec -i y444_511x511.hevc -o y444_511x511.yuv --save_output 1 --num_frames -1 --chroma_format YUV_420P --enable_yuv_format 31 $ hevcdec -i y400_511x511.hevc -o y400_511x511.yuv --save_output 1 --num_frames -1 --chroma_format YUV_420P --enable_yuv_format 31

To decode using hevcdec for YUV444 output format
$ hevcdec -i y444_511x511.hevc -o y444_511x511.yuv --save_output 1 --num_frames -1 --chroma_format YUV_444P --enable_yuv_format 31

To decode using hevcdec for YUV400 output format
$ hevcdec -i y400_511x511.hevc -o y400_511x511.yuv --save_output 1 --num_frames -1 --chroma_format GRAY --enable_yuv_format 31

Display resulting output using ffplay by passing `-f rawvideo -pixel_format yuv420p -video_size 511x511` Change pixel_format to yuv420p/yuv444p/gray based on decoder chroma_format argument