### PR TITLE
libhevcdec: Update static allocation for SAO context

### DIFF
--- a/decoder/ihevcd_api.c
+++ b/decoder/ihevcd_api.c
@@ -1385,10 +1385,8 @@ WORD32 ihevcd_allocate_static_bufs(iv_obj_t **pps_codec_obj,
     ps_codec->pv_pic_buf_base = (UWORD8 *)pv_buf;
 
     /* TO hold scratch buffers needed for each SAO context */
-    size = 4 * MAX_CTB_SIZE * MAX_CTB_SIZE;
+    size = 4 * MAX_CTB_SIZE * MAX_CTB_SIZE + 8 * MAX_CTB_SIZE * MAX_CTB_SIZE;
 
-    /* 2 temporary buffers*/
-    size *= 2;
     size *= MAX_PROCESS_THREADS;
 
     pu1_buf = pf_aligned_alloc(pv_mem_ctxt, 128, size);


### PR DESCRIPTION
Corrected the static SAO buffer size calculation to match the partitioned buffer bounds. Luma requires 4x and Chroma requires 8x MAX_CTB_SIZE * MAX_CTB_SIZE, which is now correctly summed to allocate 12x MAX_CTB_SIZE * MAX_CTB_SIZE bytes per process thread.

Bug: 484436016
Test: ./hevc_dec_fuzzer

Change-Id: I40411c04ab00d7e23843eb1d033d4943e3ec76a9