### PR TITLE
libhevcdec: Add SAO boundary checks

### DIFF
--- a/decoder/ihevcd_sao.c
+++ b/decoder/ihevcd_sao.c
@@ -829,7 +829,7 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
                             }
                             else
                             {
-                                au4_ilf_across_tile_slice_enable[6] = (ps_slice_hdr_base + au4_idx_tl[6])->i1_slice_loop_filter_across_slices_enabled_flag;
+                                au4_ilf_across_tile_slice_enable[6] = (ps_slice_hdr_base + idx_tl)->i1_slice_loop_filter_across_slices_enabled_flag;
                             }
                             if((0 == ((ps_sao_ctxt->i4_ctb_y << log2_ctb_size) / v_samp_factor) - sao_ht_chroma))
                             {
@@ -839,7 +839,16 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
                             else
                             {
                                 au4_ilf_across_tile_slice_enable[4] = (ps_slice_hdr_base + idx_tl)->i1_slice_loop_filter_across_slices_enabled_flag;
+                                au4_ilf_across_tile_slice_enable[5] = (ps_slice_hdr_base + idx_tl)->i1_slice_loop_filter_across_slices_enabled_flag;
+                            }
+
+                            if(au4_idx_tl[5] > idx_tl)
+                            {
                                 au4_ilf_across_tile_slice_enable[5] = (ps_slice_hdr_base + au4_idx_tl[5])->i1_slice_loop_filter_across_slices_enabled_flag;
+                            }
+                            if(au4_idx_tl[6] > idx_tl)
+                            {
+                                au4_ilf_across_tile_slice_enable[6] = (ps_slice_hdr_base + au4_idx_tl[6])->i1_slice_loop_filter_across_slices_enabled_flag;
                             }
                             au4_ilf_across_tile_slice_enable[2] = (ps_slice_hdr_base + idx_tl)->i1_slice_loop_filter_across_slices_enabled_flag;
                             au4_ilf_across_tile_slice_enable[0] = (ps_slice_hdr_base + idx_tl)->i1_slice_loop_filter_across_slices_enabled_flag;


### PR DESCRIPTION
For 16x16 CTB sizes in chroma processing, au4_idx_tl[5] and au4_idx_tl[6] can be set to -1 at picture boundaries. Added guards to check that the index is valid (> idx_tl) before dereferencing the slice header list.

Bug: 516422427
Test: ./hevc_dec_fuzzer

Change-Id: I40411c04ab00d7e23843eb1d033c6953e3ec76e9