### PR TITLE
hevcdec: avoid signed left shift overflow building coeff bitmasks

### DIFF
--- a/decoder/ihevcd_iquant_itrans_recon_ctb.c
+++ b/decoder/ihevcd_iquant_itrans_recon_ctb.c
@@ -403,8 +403,8 @@ UWORD8* ihevcd_unpack_coeffs(WORD16 *pi2_tu_coeff,
                 {
                     iquant_out = ps_tu_sblk_coeff_data->ai2_level[sblk_non_zero_coeff_idx++];
                 }
-                *pu4_zero_cols &= ~(0x1 << (subblk_pos_x + xs));
-                *pu4_zero_rows &= ~(0x1 << (subblk_pos_y + ys));
+                *pu4_zero_cols &= ~(0x1U << (subblk_pos_x + xs));
+                *pu4_zero_rows &= ~(0x1U << (subblk_pos_y + ys));
                 *(pi2_sblk_ptr + xs + ys * trans_size) = iquant_out;
             }
             sblk_scan_idx--;

--- a/decoder/ihevcd_parse_residual.c
+++ b/decoder/ihevcd_parse_residual.c
@@ -832,13 +832,13 @@ WORD32 ihevcd_parse_residual_coding(codec_t *ps_codec,
         {
             IHEVCD_CABAC_DECODE_BYPASS_BINS(value, ps_cabac, ps_bitstrm, num_coeff);
             AEV_TRACE("sign_flags", value, ps_cabac->u4_range);
-            u4_coeff_sign_map = value << (32 - num_coeff);
+            u4_coeff_sign_map = (UWORD32)value << (32 - num_coeff);
         }
         else
         {
             IHEVCD_CABAC_DECODE_BYPASS_BINS(value, ps_cabac, ps_bitstrm, (num_coeff - 1));
             AEV_TRACE("sign_flags", value, ps_cabac->u4_range);
-            u4_coeff_sign_map = value << (32 - (num_coeff - 1));
+            u4_coeff_sign_map = (UWORD32)value << (32 - (num_coeff - 1));
         }
 
         num_sig_coeff = 0;


### PR DESCRIPTION
1. ihevcd_parse_residual_coding builds the coefficient sign bitmap with `value << (32 - num_coeff)`, where `value` is a signed int and the shift count reaches 31, so the high sign bit is shifted into bit 31.
2. ihevcd_unpack_coeffs clears the zero_cols/zero_rows bitmasks with `0x1 << pos`, where `pos` reaches 31 for a 32x32 transform, the same signed overflow.

Both are undefined behaviour reachable from an ordinary stream (UBSan reports "left shift of 1 by 31 places cannot be represented in type 'int'" at the two sites during a normal decode). The targets are already UWORD32 bitmasks, so casting the shifted operand to unsigned makes the shift well defined and leaves the produced value unchanged.
