### PR TITLE
Pass remaining bytes when initializing bitstream structure when writi…

### DIFF
--- a/encoder/ihevce_encode_header_sei_vui.c
+++ b/encoder/ihevce_encode_header_sei_vui.c
@@ -1531,7 +1531,7 @@ WORD32 ihevce_put_sei_msg(
         //return_status = IHEVCE_FAIL;
     }
 
-    ASSERT(IHEVCE_SUCCESS == return_status);
+    /* buffer overflow is a valid runtime error, so we don't assert on it */
 
     /* rbsp trailing bits */
     if((IHEVCE_SUCCESS == return_status) && (ps_bitstrm->i4_bits_left_in_cw & 0x7))

--- a/encoder/ihevce_entropy_interface.c
+++ b/encoder/ihevce_entropy_interface.c
@@ -594,8 +594,15 @@ WORD32 ihevce_entropy_encode_frame(
             ps_curr_out->i4_bytes_generated += i4_bytes_generated;
 
             /* Re-Initialize the bitstream engine after each tile or slice */
-            ihevce_bitstrm_init(
-                ps_bitstrm, (ps_bitstrm->pu1_strm_buffer + i4_bytes_generated), out_buf_size);
+            {
+                WORD32 rem_buf_size = out_buf_size - ps_curr_out->i4_bytes_generated;
+                if(rem_buf_size < 0)
+                {
+                    rem_buf_size = 0;
+                }
+                ihevce_bitstrm_init(
+                    ps_bitstrm, (ps_bitstrm->pu1_strm_buffer + i4_bytes_generated), rem_buf_size);
+            }
         }
     }
 


### PR DESCRIPTION
…ng SEI messages

This fixes OOB access in HEVC encoder when writing SEI message

Fixes #96