### PR TITLE
deblk: avoid undefined left shift of negative chroma delta

### DIFF
--- a/common/ihevc_deblk_edge_filter.c
+++ b/common/ihevc_deblk_edge_filter.c
@@ -642,14 +642,14 @@ void ihevc_deblk_chroma_vert(UWORD8 *pu1_src,
 
     for(row = 0; row < 4; row++)
     {
-        delta_u = CLIP3((((pu1_src[0] - pu1_src[-2]) << 2) +
+        delta_u = CLIP3((((pu1_src[0] - pu1_src[-2]) * 4) +
                         pu1_src[-4] - pu1_src[2] + 4) >> 3,
                         -tc_u, tc_u);
 
         tmp_p0_u = CLIP_U8(pu1_src[-2] + delta_u);
         tmp_q0_u = CLIP_U8(pu1_src[0] - delta_u);
 
-        delta_v = CLIP3((((pu1_src[1] - pu1_src[-1]) << 2) +
+        delta_v = CLIP3((((pu1_src[1] - pu1_src[-1]) * 4) +
                         pu1_src[-3] - pu1_src[3] + 4) >> 3,
                         -tc_v, tc_v);
 
@@ -775,7 +775,7 @@ void ihevc_deblk_chroma_horz(UWORD8 *pu1_src,
     {
         tc = (col & 1) ? tc_v : tc_u;
         delta = CLIP3((((pu1_src[0 * src_strd] -
-                      pu1_src[-1 * src_strd]) << 2) +
+                      pu1_src[-1 * src_strd]) * 4) +
                       pu1_src[-2 * src_strd] -
                       pu1_src[1 * src_strd] + 4) >> 3,
                       -tc, tc);

--- a/common/ihevc_hbd_deblk_edge_filter.c
+++ b/common/ihevc_hbd_deblk_edge_filter.c
@@ -645,13 +645,13 @@ void ihevc_hbd_deblk_chroma_vert(UWORD16 *pu2_src,
 
     for(row = 0; row < 4; row++)
     {
-        delta_u = CLIP3((((pu2_src[0] - pu2_src[-2]) << 2) +
+        delta_u = CLIP3((((pu2_src[0] - pu2_src[-2]) * 4) +
                         pu2_src[-4] - pu2_src[2] + 4) >> 3,
                         -tc_u, tc_u);
         tmp_p0_u = CLIP3(pu2_src[-2] + delta_u, 0, ((1 << bit_depth) - 1));
         tmp_q0_u = CLIP3(pu2_src[0] - delta_u, 0, ((1 << bit_depth) - 1));
 
-        delta_v = CLIP3((((pu2_src[1] - pu2_src[-1]) << 2) +
+        delta_v = CLIP3((((pu2_src[1] - pu2_src[-1]) * 4) +
                         pu2_src[-3] - pu2_src[3] + 4) >> 3,
                         -tc_v, tc_v);
         tmp_p0_v = CLIP3(pu2_src[-1] + delta_v, 0, ((1 << bit_depth) - 1));
@@ -760,14 +760,14 @@ void ihevc_deblk_422chroma_vert(UWORD8 *pu1_src,
 
     for(row = 0; row < 4; row++)
     {
-        delta_u = CLIP3((((pu1_src[0] - pu1_src[-2]) << 2) +
+        delta_u = CLIP3((((pu1_src[0] - pu1_src[-2]) * 4) +
                         pu1_src[-4] - pu1_src[2] + 4) >> 3,
                         -tc_u, tc_u);
 
         tmp_p0_u = CLIP_U8(pu1_src[-2] + delta_u);
         tmp_q0_u = CLIP_U8(pu1_src[0] - delta_u);
 
-        delta_v = CLIP3((((pu1_src[1] - pu1_src[-1]) << 2) +
+        delta_v = CLIP3((((pu1_src[1] - pu1_src[-1]) * 4) +
                         pu1_src[-3] - pu1_src[3] + 4) >> 3,
                         -tc_v, tc_v);
 
@@ -879,13 +879,13 @@ void ihevc_hbd_deblk_422chroma_vert(UWORD16 *pu2_src,
 
     for(row = 0; row < 4; row++)
     {
-        delta_u = CLIP3((((pu2_src[0] - pu2_src[-2]) << 2) +
+        delta_u = CLIP3((((pu2_src[0] - pu2_src[-2]) * 4) +
                         pu2_src[-4] - pu2_src[2] + 4) >> 3,
                         -tc_u, tc_u);
         tmp_p0_u = CLIP3(pu2_src[-2] + delta_u, 0, ((1 << bit_depth) - 1));
         tmp_q0_u = CLIP3(pu2_src[0] - delta_u, 0, ((1 << bit_depth) - 1));
 
-        delta_v = CLIP3((((pu2_src[1] - pu2_src[-1]) << 2) +
+        delta_v = CLIP3((((pu2_src[1] - pu2_src[-1]) * 4) +
                         pu2_src[-3] - pu2_src[3] + 4) >> 3,
                         -tc_v, tc_v);
         tmp_p0_v = CLIP3(pu2_src[-1] + delta_v, 0, ((1 << bit_depth) - 1));
@@ -1001,7 +1001,7 @@ void ihevc_deblk_422chroma_horz
     {
         tc = (col & 1) ? tc_v : tc_u;
         delta = CLIP3((((pu1_src[0 * src_strd] -
-                      pu1_src[-1 * src_strd]) << 2) +
+                      pu1_src[-1 * src_strd]) * 4) +
                       pu1_src[-2 * src_strd] -
                       pu1_src[1 * src_strd] + 4) >> 3,
                       -tc, tc);
@@ -1125,7 +1125,7 @@ void ihevc_hbd_deblk_chroma_horz(UWORD16 *pu2_src,
     {
         tc = (col & 1) ? tc_v : tc_u;
         delta = CLIP3((((pu2_src[0 * src_strd] -
-                      pu2_src[-1 * src_strd]) << 2) +
+                      pu2_src[-1 * src_strd]) * 4) +
                       pu2_src[-2 * src_strd] -
                       pu2_src[1 * src_strd] + 4) >> 3,
                       -tc, tc);
@@ -1238,7 +1238,7 @@ void ihevc_hbd_deblk_422chroma_horz(UWORD16 *pu2_src,
     {
         tc = (col & 1) ? tc_v : tc_u;
         delta = CLIP3((((pu2_src[0 * src_strd] -
-                      pu2_src[-1 * src_strd]) << 2) +
+                      pu2_src[-1 * src_strd]) * 4) +
                       pu2_src[-2 * src_strd] -
                       pu2_src[1 * src_strd] + 4) >> 3,
                       -tc, tc);


### PR DESCRIPTION
The chroma deblocking filter builds its sample correction from the difference of two neighbouring reconstructed samples and scales it with a left shift, (p - q) << 2. Those samples come straight out of the decoded picture, so the difference is a plain signed int that is negative whenever q is the larger of the two, and a left shift of a negative value is undefined in C. UBSan reports it on a normal decode, several times per frame, while the luma edge filter right beside it already forms the same quantity with multiplication and stays clean. The same shift was copied into every chroma edge routine, including the high bit depth and 4:2:2 builds in ihevc_hbd_deblk_edge_filter.c, so I changed them together. Swapping the shift for a multiply by 4 leaves the result unchanged for the cases that were already well defined and removes the undefined path; a before/after decode of the same stream produces byte-identical YUV. I confirmed the warnings disappear under -fsanitize=undefined using the bundled hevcenc/hevcdec.