### PR TITLE
avoid undefined left shift of negative offset in weighted bi-pred

### DIFF
--- a/common/ihevc_weighted_pred.c
+++ b/common/ihevc_weighted_pred.c
@@ -314,7 +314,7 @@ void ihevc_weighted_pred_bi(WORD16 *pi2_src1,
         {
             i4_tmp = (pi2_src1[col] + lvl_shift1) * wgt0;
             i4_tmp += (pi2_src2[col] + lvl_shift2) * wgt1;
-            i4_tmp += (off0 + off1 + 1) << (shift - 1);
+            i4_tmp += (off0 + off1 + 1) * (1 << (shift - 1));
 
             pu1_dst[col] = CLIP_U8(i4_tmp >> shift);
         }
@@ -419,13 +419,13 @@ void ihevc_weighted_pred_chroma_bi(WORD16 *pi2_src1,
         {
             i4_tmp = (pi2_src1[col] + lvl_shift1) * wgt0_cb;
             i4_tmp += (pi2_src2[col] + lvl_shift2) * wgt1_cb;
-            i4_tmp += (off0_cb + off1_cb + 1) << (shift - 1);
+            i4_tmp += (off0_cb + off1_cb + 1) * (1 << (shift - 1));
 
             pu1_dst[col] = CLIP_U8(i4_tmp >> shift);
 
             i4_tmp = (pi2_src1[col + 1] + lvl_shift1) * wgt0_cr;
             i4_tmp += (pi2_src2[col + 1] + lvl_shift2) * wgt1_cr;
-            i4_tmp += (off0_cr + off1_cr + 1) << (shift - 1);
+            i4_tmp += (off0_cr + off1_cr + 1) * (1 << (shift - 1));
 
             pu1_dst[col + 1] = CLIP_U8(i4_tmp >> shift);
         }


### PR DESCRIPTION
the weighted bi-prediction reference functions (ihevc_weighted_pred_bi and the cb/cr terms of ihevc_weighted_pred_chroma_bi) build the rounding term as (off0 + off1 + 1) << (shift - 1), but the luma/chroma offsets parsed from the slice header are signed and routinely negative, so left-shifting that sum is undefined behaviour flagged by ubsan on any decode using explicit weighted bi-prediction; multiplying by (1 << (shift - 1)) instead keeps the value identical for all legal offsets and removes the ub.