### PR TITLE
read no_loop_filter flags via memcpy to avoid unaligned access

### DIFF
--- a/decoder/ihevcd_process_slice.c
+++ b/decoder/ihevcd_process_slice.c
@@ -1074,7 +1074,9 @@ IHEVCD_ERROR_T ihevcd_process(process_ctxt_t *ps_proc)
                         for(row = 0; row < (ctb_size >> 3) + 1; row++)
                         {
                             /* Go to the corresponding byte - read 32 bits and downshift */
-                            ps_proc->s_deblk_ctxt.au2_ctb_no_loop_filter_flag[row] = (*(UWORD32 *)(ps_proc->pu1_pic_no_loop_filter_flag + (bit_pos >> 3))) >> (bit_pos & 7);
+                            UWORD32 u4_loop_filter_word;
+                            memcpy(&u4_loop_filter_word, ps_proc->pu1_pic_no_loop_filter_flag + (bit_pos >> 3), sizeof(u4_loop_filter_word));
+                            ps_proc->s_deblk_ctxt.au2_ctb_no_loop_filter_flag[row] = u4_loop_filter_word >> (bit_pos & 7);
                             bit_pos += loop_filter_strd;
                         }
                     }

--- a/decoder/ihevcd_sao.c
+++ b/decoder/ihevcd_sao.c
@@ -217,8 +217,9 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
             {
                 WORD32 tmp_wd = sao_blk_wd;
 
-                u4_no_loop_filter_flag = (*(UWORD32 *)(pu1_no_loop_filter_flag + i * loop_filter_strd)) >>
-                                (loop_filter_bit_pos & 7);
+                UWORD32 u4_loop_filter_word;
+                memcpy(&u4_loop_filter_word, pu1_no_loop_filter_flag + i * loop_filter_strd, sizeof(u4_loop_filter_word));
+                u4_no_loop_filter_flag = u4_loop_filter_word >> (loop_filter_bit_pos & 7);
                 u4_no_loop_filter_flag &= (1 << ((tmp_wd + (min_cu - 1)) >> log2_min_cu)) - 1;
 
                 if(u4_no_loop_filter_flag)
@@ -297,8 +298,9 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
             {
                 WORD32 tmp_wd = sao_blk_wd;
 
-                u4_no_loop_filter_flag = (*(UWORD32 *)(pu1_no_loop_filter_flag + i * loop_filter_strd)) >>
-                                (loop_filter_bit_pos & 7);
+                UWORD32 u4_loop_filter_word;
+                memcpy(&u4_loop_filter_word, pu1_no_loop_filter_flag + i * loop_filter_strd, sizeof(u4_loop_filter_word));
+                u4_no_loop_filter_flag = u4_loop_filter_word >> (loop_filter_bit_pos & 7);
                 u4_no_loop_filter_flag &= (1 << ((tmp_wd + (min_cu - 1)) >> log2_min_cu)) - 1;
 
                 if(u4_no_loop_filter_flag)
@@ -2952,8 +2954,9 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
             {
                 WORD32 tmp_wd = sao_blk_wd;
 
-                u4_no_loop_filter_flag = (*(UWORD32 *)(pu1_no_loop_filter_flag + i * loop_filter_strd)) >>
-                                (loop_filter_bit_pos & 7);
+                UWORD32 u4_loop_filter_word;
+                memcpy(&u4_loop_filter_word, pu1_no_loop_filter_flag + i * loop_filter_strd, sizeof(u4_loop_filter_word));
+                u4_no_loop_filter_flag = u4_loop_filter_word >> (loop_filter_bit_pos & 7);
                 u4_no_loop_filter_flag &= (1 << ((tmp_wd + (min_cu - 1)) >> log2_min_cu)) - 1;
 
                 if(u4_no_loop_filter_flag)
@@ -3030,8 +3033,9 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
             {
                 WORD32 tmp_wd = sao_blk_wd;
 
-                u4_no_loop_filter_flag = (*(UWORD32 *)(pu1_no_loop_filter_flag + i * loop_filter_strd)) >>
-                                (loop_filter_bit_pos & 7);
+                UWORD32 u4_loop_filter_word;
+                memcpy(&u4_loop_filter_word, pu1_no_loop_filter_flag + i * loop_filter_strd, sizeof(u4_loop_filter_word));
+                u4_no_loop_filter_flag = u4_loop_filter_word >> (loop_filter_bit_pos & 7);
                 u4_no_loop_filter_flag &= (1 << ((tmp_wd + (min_cu - 1)) >> log2_min_cu)) - 1;
 
                 if(u4_no_loop_filter_flag)


### PR DESCRIPTION
1. pu1_pic_no_loop_filter_flag is a UWORD8 array, but ihevcd_sao_shift_ctb and the deblock CTB setup in ihevcd_process read 32 of its bits at a time through a (UWORD32 *) cast of the byte pointer.
2. that load is unaligned and type-puns the byte buffer as UWORD32, which is undefined behaviour. UBSan reports "load of misaligned address ... requires 4 byte alignment" at the five sites on an ordinary decode (4:2:0/4:2:2/4:4:4/monochrome).

Switched the reads to memcpy into a UWORD32, which loads the same four bytes and value (decoded output is bit-identical) without the UB.