### PR TITLE
hevcdec: update chroma subsample filter from neighbor to area

### DIFF
--- a/decoder/ihevcd_fmt_conv.c
+++ b/decoder/ihevcd_fmt_conv.c
@@ -616,8 +616,30 @@ void ihevcd_fmt_conv_444sp_to_420p(UWORD8 *pu1_y_src,
     {
         for(WORD32 j = 0; j < wd; j += 2)
         {
-            pu1_u_dst[j / 2] = pu1_uv_src[j * 2];
-            pu1_v_dst[j / 2] = pu1_uv_src[j * 2 + 1];
+            WORD32 cb_sum = pu1_uv_src[j * 2];
+            WORD32 cr_sum = pu1_uv_src[j * 2 + 1];
+            WORD32 count = 1;
+
+            if((j + 1) < wd)
+            {
+                cb_sum += pu1_uv_src[(j + 1) * 2];
+                cr_sum += pu1_uv_src[(j + 1) * 2 + 1];
+                count++;
+            }
+            if((i + 1) < ht)
+            {
+                cb_sum += pu1_uv_src[j * 2 + src_uv_strd];
+                cr_sum += pu1_uv_src[j * 2 + src_uv_strd + 1];
+                count++;
+            }
+            if((j + 1) < wd && (i + 1) < ht)
+            {
+                cb_sum += pu1_uv_src[(j + 1) * 2 + src_uv_strd];
+                cr_sum += pu1_uv_src[(j + 1) * 2 + src_uv_strd + 1];
+                count++;
+            }
+            pu1_u_dst[j / 2] = (cb_sum + (count >> 1)) / count;
+            pu1_v_dst[j / 2] = (cr_sum + (count >> 1)) / count;
         }
         pu1_u_dst += dst_uv_strd;
         pu1_v_dst += dst_uv_strd;
@@ -680,8 +702,19 @@ void ihevcd_fmt_conv_422sp_to_420p(UWORD8 *pu1_y_src,
     {
         for(WORD32 j = 0; j < wd; j += 2)
         {
-            pu1_u_dst[j / 2] = pu1_uv_src[j];
-            pu1_v_dst[j / 2] = pu1_uv_src[j + 1];
+            WORD32 cb_sum = pu1_uv_src[j];
+            WORD32 cr_sum = pu1_uv_src[j + 1];
+
+            if((i + 1) < ht)
+            {
+                cb_sum += pu1_uv_src[j + src_uv_strd] + 1;
+                cr_sum += pu1_uv_src[j + 1 + src_uv_strd] + 1;
+
+                cb_sum >>= 1;
+                cr_sum >>= 1;
+            }
+            pu1_u_dst[j / 2] = cb_sum;
+            pu1_v_dst[j / 2] = cr_sum;
         }
         pu1_u_dst += dst_uv_strd;
         pu1_v_dst += dst_uv_strd;

--- a/decoder/ihevcd_parse_slice.c
+++ b/decoder/ihevcd_parse_slice.c
@@ -1959,9 +1959,9 @@ IHEVCD_ERROR_T ihevcd_parse_coding_quadtree(codec_t *ps_codec,
     IHEVCD_ERROR_T ret = (IHEVCD_ERROR_T)IHEVCD_SUCCESS;
     sps_t *ps_sps;
     pps_t *ps_pps;
-    #ifdef ENABLE_MAIN_REXT_PROFILE
+#ifdef ENABLE_MAIN_REXT_PROFILE
     slice_header_t *ps_slice_hdr;
-    #endif
+#endif
     WORD32 split_cu_flag;
     WORD32 x1, y1;
     WORD32 cu_pos_x;
@@ -1971,9 +1971,9 @@ IHEVCD_ERROR_T ihevcd_parse_coding_quadtree(codec_t *ps_codec,
     WORD32 cb_size = 1 << log2_cb_size;
     ps_sps = ps_codec->s_parse.ps_sps;
     ps_pps = ps_codec->s_parse.ps_pps;
-    #ifdef ENABLE_MAIN_REXT_PROFILE
+#ifdef ENABLE_MAIN_REXT_PROFILE
     ps_slice_hdr = ps_codec->s_parse.ps_slice_hdr;
-    #endif
+#endif
 
     /* Compute CU position with respect to current CTB in (8x8) units */
     cu_pos_x = (x0 - (ps_codec->s_parse.i4_ctb_x << ps_sps->i1_log2_ctb_size)) >> 3;


### PR DESCRIPTION
For clips with chroma format idc 444/422 and output format selected to 420, after decoding during chroma sampling conversion from 444/422 to 420, neighbor filtering is done currently. This is updated to area.

Test: ./hevcdec
Change-Id: I024886655084051093858c5c40a94c0373c64813