### PR TITLE
avoid signed left shift overflow in ihevcd_bits_seek

### DIFF
--- a/decoder/ihevcd_bitstream.c
+++ b/decoder/ihevcd_bitstream.c
@@ -226,7 +226,7 @@ void ihevcd_bits_flush_to_byte_boundary(bitstrm_t *ps_bitstrm)
 */
 void ihevcd_bits_seek(bitstrm_t *ps_bitstrm, WORD32 numbits)
 {
-    WORD32 val;
+    UWORD32 val;
     ASSERT(numbits >= -32);
     ASSERT(numbits <= 32);
     /* Check if Seeking backwards*/


### PR DESCRIPTION
1. ihevcd_bits_seek holds the reloaded 4-byte word in a signed WORD32 val, then ITT_BIG_ENDIAN shifts its low byte left by 24, so any byte >= 0x80 lands in the sign bit.
2. left-shifting a negative/overflowing signed int is undefined; UBSan reports it at ihevcd_bitstream.c:256 on a normal decode, reached through ihevcd_cabac_decode_terminate.
Changed val to UWORD32 to match ihevcd_bits_init and the BITS_FLUSH/BITS_GET/BIT_GET macros, which already keep this word unsigned. The swapped result is stored into the UWORD32 u4_cur_word, so decoded output is unchanged.