### PR TITLE
fix oob slice-index read in ihevcd_sao_shift_ctb

### DIFF
--- a/decoder/ihevcd_sao.c
+++ b/decoder/ihevcd_sao.c
@@ -815,7 +815,8 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
                                 else
                                 {
                                     au4_idx_tl[5] = pu1_slice_idx[(ctbx_tl_l + 1) + (ctby_tl_l * ps_sps->i2_pic_wd_in_ctb)];
-                                    au4_idx_tl[4] = pu1_slice_idx[(ctbx_tl_t - 1) + (ctby_tl_t * ps_sps->i2_pic_wd_in_ctb)];
+                                    if(ctbx_tl_t > 0)
+                                        au4_idx_tl[4] = pu1_slice_idx[(ctbx_tl_t - 1) + (ctby_tl_t * ps_sps->i2_pic_wd_in_ctb)];
                                 }
                                 au4_idx_tl[7] = pu1_slice_idx[(ctbx_tl_d + 1) + (ctby_tl_d * ps_sps->i2_pic_wd_in_ctb)];
                             }


### PR DESCRIPTION
1. for a 16x16 CTB at the left picture edge (i4_ctb_x == 1) in the chroma edge-offset path, ctbx_tl_t and ctby_tl_t stay 0, so au4_idx_tl[4] = pu1_slice_idx[(ctbx_tl_t - 1) + (ctby_tl_t * i2_pic_wd_in_ctb)] reads pu1_slice_idx[-1], out of bounds of pu1_pic_slice_map.
2. the i4_ctb_x == 1 branch already sets au4_idx_tl[4] to the -1 sentinel, so only recompute it from the neighbor when ctbx_tl_t > 0.

Reachable on a multi-slice stream with 16x16 CTBs and chroma edge-offset SAO; the earlier -1 guards on au4_idx_tl[5]/[6] left this index read uncovered.