### PR TITLE
fix oob top-left pu-map read in ihevcd_get_mv_ctb

### DIFF
--- a/decoder/ihevcd_get_mv.c
+++ b/decoder/ihevcd_get_mv.c
@@ -222,11 +222,15 @@ WORD32 ihevcd_get_mv_ctb(mv_ctxt_t *ps_mv_ctxt,
             }
 
 
-            index_pic_map = ((ps_mv_ctxt->i4_ctb_x - 1) + (ps_mv_ctxt->i4_ctb_y - 1) * ps_sps->i2_pic_wd_in_ctb);
-            ctb_pu_idx = ps_mv_ctxt->pu4_pic_pu_idx[index_pic_map];
-            index_pic_map *= num_minpu_in_ctb;
-            index_pic_map += (num_minpu_in_ctb - 1);
-            pu4_ctb_top_left_pu_idx[0] = ctb_pu_idx + pu1_pic_pu_map[index_pic_map];
+            /* Top left ctb is a valid neighbor only when a row above exists */
+            if(ps_mv_ctxt->i4_ctb_y != 0)
+            {
+                index_pic_map = ((ps_mv_ctxt->i4_ctb_x - 1) + (ps_mv_ctxt->i4_ctb_y - 1) * ps_sps->i2_pic_wd_in_ctb);
+                ctb_pu_idx = ps_mv_ctxt->pu4_pic_pu_idx[index_pic_map];
+                index_pic_map *= num_minpu_in_ctb;
+                index_pic_map += (num_minpu_in_ctb - 1);
+                pu4_ctb_top_left_pu_idx[0] = ctb_pu_idx + ps_mv_ctxt->pu1_pic_pu_map[index_pic_map];
+            }
         }
         /*Top*/
         /* If start of tile column*/


### PR DESCRIPTION
1. at a vertical tile boundary the top-left neighbor read uses the local pu1_pic_pu_map pointer, already advanced by the preceding left-column replication loop, as the base for an absolute map offset; the sibling left and top blocks index from ps_mv_ctxt->pu1_pic_pu_map, so only this read runs off the end of the num_pu-byte pu1_pic_pu_map buffer.
2. the same block also runs when i4_ctb_y == 0, where the top-left ctb at (i4_ctb_x-1, i4_ctb_y-1) does not exist, so index_pic_map is negative and both pu4_pic_pu_idx[index_pic_map] and the map read underflow.

Guarded the block on i4_ctb_y != 0 like the adjacent top block and indexed from the buffer base. Reproduced on a 2 tile-column stream (kvazaar --tiles 2x1, P frames): asan reports a heap-buffer-overflow read at ihevcd_get_mv.c:229 reached from ihevcd_parse_slice_data. Decoded output is unchanged after the fix.