### PR TITLE
[tests] Allocate extra bytes for x86 and x64 SIMD tests

### DIFF
--- a/tests/common/ihevc_itrans_recon_test.cc
+++ b/tests/common/ihevc_itrans_recon_test.cc
@@ -29,18 +29,29 @@ protected:
     pred_strd = trans_size;
     dst_strd = trans_size;
 
+    // TODO: Increase allocations for x86/x86_64 to avoid out-of-bounds
+    // reads in SIMD implementations.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
+    defined(_M_IX86)
+    int pad_pred = (trans_size == 4) ? 8 : 0;
+    int pad_tmp = (trans_size == 32) ? 8 : 0;
+#else
+    int pad_pred = 0;
+    int pad_tmp = 0;
+#endif
+
     pi2_src.resize(trans_size * trans_size);
     // pi2_tmp needs to be large enough to hold intermediate data of width *
     // height 16bits.
-    pi2_tmp.resize(trans_size * trans_size);
+    pi2_tmp.resize(trans_size * trans_size + pad_tmp);
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
--    defined(_M_IX86)
+    defined(_M_IX86)
   if (trans_size == 32) {
     // SSE4.2 and SSSE3.1 require 3 times trans_size * trans_size for 32x32
-    pi2_tmp.resize(3 * trans_size * trans_size);
+    pi2_tmp.resize(3 * trans_size * trans_size + pad_tmp);
   }
 #endif
-    pu1_pred.resize(trans_size * trans_size);
+    pu1_pred.resize(trans_size * trans_size + pad_pred);
     pu1_dst_ref.resize(trans_size * trans_size);
     pu1_dst_tst.resize(trans_size * trans_size);
 

--- a/tests/common/ihevc_luma_inter_pred_test.cc
+++ b/tests/common/ihevc_luma_inter_pred_test.cc
@@ -53,8 +53,17 @@ protected:
     src_strd = wd * src_strd_mul;
     dst_strd = wd * dst_strd_mul;
 
-    dst_buf_ref.resize(dst_strd * ht);
-    dst_buf_tst.resize(dst_strd * ht);
+    // TODO: Increase allocations for x86/x86_64 to avoid out-of-bounds
+    // reads/writes in SIMD implementations.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
+    defined(_M_IX86)
+    int pad_dst = 16;
+#else
+    int pad_dst = 0;
+#endif
+
+    dst_buf_ref.resize(dst_strd * ht + pad_dst);
+    dst_buf_tst.resize(dst_strd * ht + pad_dst);
 
     // Set pv_src to a valid position within src_buf to allow negative indexing
     pv_src = (srcType *)g_src8_buf.data() + kTapSize / 2 * src_strd;

--- a/tests/common/ihevc_luma_intra_pred_test.cc
+++ b/tests/common/ihevc_luma_intra_pred_test.cc
@@ -47,9 +47,20 @@ protected:
     src_strd = 1; // Intra pred reference is usually dense
     dst_strd = nt * dst_strd_mul;
 
+    // TODO: Increase allocations for x86/x86_64 to avoid out-of-bounds
+    // reads/writes in SIMD implementations.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
+    defined(_M_IX86)
+    int pad_ref = 16;
+    int pad_dst = 16;
+#else
+    int pad_ref = 0;
+    int pad_dst = 0;
+#endif
+
     // Reference buffer size: 4 * nt + 1
     int ref_size = 4 * nt + 1;
-    ref_buf.resize(ref_size);
+    ref_buf.resize(ref_size + pad_ref);
 
     // Initialize reference buffer with random data
     std::mt19937 rng(12345);
@@ -64,8 +75,8 @@ protected:
     // We just pass the data pointer.
     pu1_ref = ref_buf.data();
 
-    dst_buf_ref.resize(dst_strd * nt);
-    dst_buf_tst.resize(dst_strd * nt);
+    dst_buf_ref.resize(dst_strd * nt + pad_dst);
+    dst_buf_tst.resize(dst_strd * nt + pad_dst);
 
     // Initialize dst buffers with pattern to detect over/under writes
     std::fill(dst_buf_ref.begin(), dst_buf_ref.end(), 0xCD);

--- a/tests/common/tests_common.cc
+++ b/tests/common/tests_common.cc
@@ -46,8 +46,14 @@ const std::vector<std::pair<int, int>> kPUBlockSizes = {
 };
 
 const std::vector<UWORD8> g_src8_buf = []() {
-  // allocate twice to account for WORD16 as well
+  // TODO: Increase allocations for x86/x86_64 to avoid out-of-bounds
+  // reads in SIMD/C implementations when stride multiplier is 2.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
+    defined(_M_IX86)
+  std::vector<UWORD8> buf(kMaxSize * kMaxHeight * 4);
+#else
   std::vector<UWORD8> buf(kMaxSize * kMaxHeight * 2);
+#endif
   std::mt19937 rng(12345);
   std::uniform_int_distribution<int> dist(0, 255);
   for (auto &v : buf)


### PR DESCRIPTION
Few SSE42 and SSSE31 assemblies read additional bytes (due to 128bit reads) and to avoid OOB access, the buffers are allocated for a larger size for x86/x64 tests.