### PR TITLE
[cmake] Add support for generating coverage reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(libhevc C CXX)
 
+option(ENABLE_COVERAGE "Enable coverage" OFF)
+if(ENABLE_COVERAGE)
+  add_compile_options(-O0 -g)
+endif()
+
+
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -28,6 +28,9 @@ function(libhevc_add_compile_options)
     add_compile_options(-fno-omit-frame-pointer -fsanitize=${SANITIZE})
   endif()
 
+  if(ENABLE_COVERAGE)
+    add_compile_options(--coverage)
+  endif()
 endfunction()
 
 # Adds defintions for all targets
@@ -51,7 +54,11 @@ endfunction()
 
 # Adds libraries needed for executables
 function(libhevc_set_link_libraries)
-  link_libraries(Threads::Threads m)
+  if(ENABLE_COVERAGE)
+    link_libraries(Threads::Threads m --coverage)
+  else()
+    link_libraries(Threads::Threads m)
+  endif()
 endfunction()
 
 # cmake-format: off


### PR DESCRIPTION
use ENABLE_COVERAGE argument for cmake builds for enabling coverage