### PR TITLE
Move IVD_ARCH_T and IVD_SOC_T to iv.h and rename as IV_ARCH_T and IV_…

### DIFF
--- a/common/iv.h
+++ b/common/iv.h
@@ -137,6 +137,36 @@ typedef enum {
     IV_CMD_DUMMY_ELEMENT                = 0x4,
 }IV_API_COMMAND_TYPE_T;
 
+/* IV_ARCH_T: Architecture Enumeration                               */
+typedef enum
+{
+    ARCH_NA                 =   0x7FFFFFFF,
+    ARCH_ARM_NONEON         =   0x0,
+    ARCH_ARM_A9Q,
+    ARCH_ARM_A9A,
+    ARCH_ARM_A9,
+    ARCH_ARM_A7,
+    ARCH_ARM_A5,
+    ARCH_ARM_A15,
+    ARCH_ARM_NEONINTR,
+    ARCH_ARMV8_GENERIC,
+    ARCH_X86_GENERIC        =   0x100,
+    ARCH_X86_SSSE3,
+    ARCH_X86_SSE42,
+    ARCH_X86_AVX2,
+    ARCH_MIPS_GENERIC       =   0x200,
+    ARCH_MIPS_32,
+    ARCH_RISCV64_GENERIC    =   0x400,
+}IV_ARCH_T;
+
+/* IV_SOC_T: SOC Enumeration                               */
+typedef enum
+{
+    SOC_NA                  = 0x7FFFFFFF,
+    SOC_GENERIC             = 0x0,
+    SOC_HISI_37X            = 0x100,
+}IV_SOC_T;
+
 /*****************************************************************************/
 /* Structure                                                                 */
 /*****************************************************************************/

--- a/common/ivd.h
+++ b/common/ivd.h
@@ -49,36 +49,6 @@
 /* Enums                                                                     */
 /*****************************************************************************/
 
-/* IVD_ARCH_T: Architecture Enumeration                               */
-typedef enum
-{
-    ARCH_NA                 =   0x7FFFFFFF,
-    ARCH_ARM_NONEON         =   0x0,
-    ARCH_ARM_A9Q,
-    ARCH_ARM_A9A,
-    ARCH_ARM_A9,
-    ARCH_ARM_A7,
-    ARCH_ARM_A5,
-    ARCH_ARM_A15,
-    ARCH_ARM_NEONINTR,
-    ARCH_ARMV8_GENERIC,
-    ARCH_X86_GENERIC        =   0x100,
-    ARCH_X86_SSSE3,
-    ARCH_X86_SSE42,
-    ARCH_X86_AVX2,
-    ARCH_MIPS_GENERIC       =   0x200,
-    ARCH_MIPS_32,
-    ARCH_RISCV64_GENERIC    =   0x400,
-}IVD_ARCH_T;
-
-/* IVD_SOC_T: SOC Enumeration                               */
-typedef enum
-{
-    SOC_NA                  = 0x7FFFFFFF,
-    SOC_GENERIC             = 0x0,
-    SOC_HISI_37X            = 0x100,
-}IVD_SOC_T;
-
 /* IVD_FRAME_SKIP_MODE_T:Skip mode Enumeration                               */
 
 typedef enum {

--- a/decoder/ihevcd_api.c
+++ b/decoder/ihevcd_api.c
@@ -3622,8 +3622,8 @@ WORD32 ihevcd_set_processor(iv_obj_t *ps_codec_obj,
     ps_ip = (ihevcd_cxa_ctl_set_processor_ip_t *)pv_api_ip;
     ps_op = (ihevcd_cxa_ctl_set_processor_op_t *)pv_api_op;
 
-    ps_codec->e_processor_arch = (IVD_ARCH_T)ps_ip->u4_arch;
-    ps_codec->e_processor_soc = (IVD_SOC_T)ps_ip->u4_soc;
+    ps_codec->e_processor_arch = (IV_ARCH_T)ps_ip->u4_arch;
+    ps_codec->e_processor_soc = (IV_SOC_T)ps_ip->u4_soc;
 
     ihevcd_init_function_ptr(ps_codec);
 

--- a/decoder/ihevcd_structs.h
+++ b/decoder/ihevcd_structs.h
@@ -2296,9 +2296,9 @@ struct _codec_t
     /**  Funtion pointers for all the leaf level functions */
     func_selector_t s_func_selector;
     /**  Processor architecture */
-    IVD_ARCH_T e_processor_arch;
+    IV_ARCH_T e_processor_arch;
     /**  Processor soc */
-    IVD_SOC_T e_processor_soc;
+    IV_SOC_T e_processor_soc;
 
     /** Display buffer array - for shared mode */
     ivd_out_bufdesc_t s_disp_buffer[IVD_VIDDEC_MAX_IO_BUFFERS];

--- a/examples/decoder/main.c
+++ b/examples/decoder/main.c
@@ -180,8 +180,8 @@ typedef struct
     UWORD32 u4_chksum_save_flag;
     UWORD32 u4_max_frm_ts;
     IV_COLOR_FORMAT_T e_output_chroma_format;
-    IVD_ARCH_T e_arch;
-    IVD_SOC_T e_soc;
+    IV_ARCH_T e_arch;
+    IV_SOC_T e_soc;
     UWORD32 dump_q_rd_idx;
     UWORD32 dump_q_wr_idx;
     WORD32  disp_q_wr_idx;

--- a/fuzzer/hevc_dec_fuzzer.cpp
+++ b/fuzzer/hevc_dec_fuzzer.cpp
@@ -43,7 +43,7 @@ const IV_COLOR_FORMAT_T supportedColorFormats[] = {
 /* Decoder ignores invalid arch, i.e. for arm build, if SSSE3 is requested,
  * decoder defaults to a supported configuration. So same set of supported
  * architectures can be used in arm/arm64/x86 builds */
-const IVD_ARCH_T supportedArchitectures[] = {
+const IV_ARCH_T supportedArchitectures[] = {
     ARCH_ARM_NONEON,  ARCH_ARM_A9Q,   ARCH_ARM_NEONINTR, ARCH_ARMV8_GENERIC,
     ARCH_X86_GENERIC, ARCH_X86_SSSE3, ARCH_X86_SSE42};
 
@@ -186,7 +186,7 @@ void Codec::setArchitecture(FuzzedDataProvider &fdp) {
   s_ctl_ip.e_cmd = IVD_CMD_VIDEO_CTL;
   s_ctl_ip.e_sub_cmd =
       (IVD_CONTROL_API_COMMAND_TYPE_T)IHEVCD_CXA_CMD_CTL_SET_PROCESSOR;
-  s_ctl_ip.u4_arch = (IVD_ARCH_T)fdp.PickValueInArray(supportedArchitectures);
+  s_ctl_ip.u4_arch = (IV_ARCH_T)fdp.PickValueInArray(supportedArchitectures);
   s_ctl_ip.u4_soc = SOC_GENERIC;
   s_ctl_ip.u4_size = sizeof(ihevcd_cxa_ctl_set_processor_ip_t);
   s_ctl_op.u4_size = sizeof(ihevcd_cxa_ctl_set_processor_op_t);

--- a/tests/common/TestCommon.cc
+++ b/tests/common/TestCommon.cc
@@ -61,7 +61,7 @@ const std::vector<UWORD8> g_src8_buf = []() {
   return buf;
 }();
 
-std::string get_arch_str(IVD_ARCH_T arch) {
+std::string get_arch_str(IV_ARCH_T arch) {
   std::string arch_str;
   switch (arch) {
     case ARCH_X86_GENERIC:
@@ -89,7 +89,7 @@ std::string get_arch_str(IVD_ARCH_T arch) {
   return arch_str;
 }
 
-const std::vector<IVD_ARCH_T> ga_tst_arch = {
+const std::vector<IV_ARCH_T> ga_tst_arch = {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || \
     defined(_M_IX86)
     ARCH_X86_SSSE3,

--- a/tests/common/TestCommon.h
+++ b/tests/common/TestCommon.h
@@ -46,7 +46,7 @@ static constexpr int kMaxHeight = kMaxSize + kTapSize;
 
 extern const std::vector<std::pair<int, int>> kPUBlockSizes;
 extern const std::vector<UWORD8> g_src8_buf;
-extern const std::vector<IVD_ARCH_T> ga_tst_arch;
+extern const std::vector<IV_ARCH_T> ga_tst_arch;
 
 // Compare outputs
 template <typename T>
@@ -62,4 +62,4 @@ static void compare_output(const std::vector<T>& ref,
   }
 }
 
-std::string get_arch_str(IVD_ARCH_T arch);
+std::string get_arch_str(IV_ARCH_T arch);

--- a/tests/common/func_selector.cc
+++ b/tests/common/func_selector.cc
@@ -90,7 +90,7 @@ const func_selector_t test_arm32 = []() {
 
 const func_selector_t *get_ref_func_ptr() { return &ref; }
 
-const func_selector_t *get_tst_func_ptr(IVD_ARCH_T arch) {
+const func_selector_t *get_tst_func_ptr(IV_ARCH_T arch) {
   switch (arch) {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
     defined(_M_IX86)

--- a/tests/common/func_selector.h
+++ b/tests/common/func_selector.h
@@ -36,6 +36,6 @@
 // clang-format on
 
 const func_selector_t *get_ref_func_ptr();
-const func_selector_t *get_tst_func_ptr(IVD_ARCH_T arch);
+const func_selector_t *get_tst_func_ptr(IV_ARCH_T arch);
 
 #endif /* __FUNC_SELECTOR_H__ */

--- a/tests/common/ihevc_chroma_inter_pred_test.cc
+++ b/tests/common/ihevc_chroma_inter_pred_test.cc
@@ -40,7 +40,7 @@
 // Test parameters: width, height, src_stride_mul, dst_stride_mul, coeff_idx,
 // arch
 using ChromaInterPredTestParam =
-    std::tuple<std::pair<int, int>, int, int, int, IVD_ARCH_T>;
+    std::tuple<std::pair<int, int>, int, int, int, IV_ARCH_T>;
 
 template <typename srcType, typename dstType>
 class ChromaInterPredTest
@@ -94,7 +94,7 @@ class ChromaInterPredTest
   dstType* pv_dst_ref;
   dstType* pv_dst_tst;
   WORD8* pi1_coeffs;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -170,7 +170,7 @@ auto kChromaInterPredTestParams = ::testing::Combine(
 std::string PrintChromaInterPredTestParam(
     const testing::TestParamInfo<ChromaInterPredTestParam>& info) {
   int wd, ht, src_strd_mul, dst_strd_mul, coeff_idx;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::pair<int, int> block_size;
   std::tie(block_size, src_strd_mul, dst_strd_mul, coeff_idx, arch) =
       info.param;

--- a/tests/common/ihevc_chroma_intra_pred_test.cc
+++ b/tests/common/ihevc_chroma_intra_pred_test.cc
@@ -38,7 +38,7 @@
 // clang-format on
 
 // Test parameters: block_size, mode, dst_stride_mul, arch
-using ChromaIntraPredTestParam = std::tuple<int, int, int, IVD_ARCH_T>;
+using ChromaIntraPredTestParam = std::tuple<int, int, int, IV_ARCH_T>;
 
 class ChromaIntraPredTest
     : public ::testing::TestWithParam<ChromaIntraPredTestParam> {
@@ -102,7 +102,7 @@ class ChromaIntraPredTest
   UWORD8* pu1_ref;
   UWORD8* pu1_dst_ref;
   UWORD8* pu1_dst_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -135,7 +135,7 @@ TEST_P(ChromaIntraPredTest, Run) {
 std::string PrintChromaIntraPredTestParam(
     const testing::TestParamInfo<ChromaIntraPredTestParam>& info) {
   int nt, mode, dst_strd_mul;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(nt, mode, dst_strd_mul, arch) = info.param;
   std::stringstream ss;
   ss << "nt_" << nt << "_mode_" << mode << "_dst_stride_"

--- a/tests/common/ihevc_chroma_itrans_recon_test.cc
+++ b/tests/common/ihevc_chroma_itrans_recon_test.cc
@@ -38,7 +38,7 @@
 namespace {
 
 // Test parameters: trans_size, arch, non_zero_rows, non_zero_cols
-using ITransReconTestParam = std::tuple<int, IVD_ARCH_T, int, int>;
+using ITransReconTestParam = std::tuple<int, IV_ARCH_T, int, int>;
 
 class ChromaITransReconTest
     : public ::testing::TestWithParam<ITransReconTestParam> {
@@ -114,7 +114,7 @@ class ChromaITransReconTest
   }
 
   int trans_size;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* ref;
   const func_selector_t* tst;
 
@@ -145,7 +145,7 @@ TEST_P(ChromaITransReconTest, Run) {
 std::string PrintChromaITransReconTestParam(
     const testing::TestParamInfo<ITransReconTestParam>& info) {
   WORD32 trans_size, non_zero_rows, non_zero_cols;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(trans_size, arch, non_zero_rows, non_zero_cols) = info.param;
   std::stringstream ss;
   ss << "size_" << trans_size << "_nzr_" << non_zero_rows << "_nzc_"

--- a/tests/common/ihevc_chroma_recon_test.cc
+++ b/tests/common/ihevc_chroma_recon_test.cc
@@ -38,7 +38,7 @@
 namespace {
 
 // Test parameters: trans_size, arch, non_zero_cols, offset (0 for U, 1 for V)
-using ChromaReconTestParam = std::tuple<int, IVD_ARCH_T, int, int>;
+using ChromaReconTestParam = std::tuple<int, IV_ARCH_T, int, int>;
 
 class ChromaReconTest : public ::testing::TestWithParam<ChromaReconTestParam> {
  protected:
@@ -104,7 +104,7 @@ class ChromaReconTest : public ::testing::TestWithParam<ChromaReconTestParam> {
 
   int trans_size;
   int offset;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* ref;
   const func_selector_t* tst;
 
@@ -133,7 +133,7 @@ TEST_P(ChromaReconTest, Run) {
 std::string PrintChromaReconTestParam(
     const testing::TestParamInfo<ChromaReconTestParam>& info) {
   WORD32 trans_size, non_zero_cols, offset;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(trans_size, arch, non_zero_cols, offset) = info.param;
   std::stringstream ss;
   ss << "size_" << trans_size << "_nzc_" << non_zero_cols << "_component_"

--- a/tests/common/ihevc_deblk_test.cc
+++ b/tests/common/ihevc_deblk_test.cc
@@ -54,13 +54,13 @@ std::string format_int(int val) {
 
 // Param: bs, qp_p, qp_q, beta_offset, tc_offset, filter_pair(p, q), arch
 using DeblkLumaParam =
-    std::tuple<int, int, int, int, int, std::pair<int, int>, IVD_ARCH_T>;
+    std::tuple<int, int, int, int, int, std::pair<int, int>, IV_ARCH_T>;
 
 std::string PrintDeblkLumaParam(
     const testing::TestParamInfo<DeblkLumaParam>& info) {
   int bs, qp_p, qp_q, beta_offset, tc_offset;
   std::pair<int, int> filter_pair;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(bs, qp_p, qp_q, beta_offset, tc_offset, filter_pair, arch) =
       info.param;
   return "bs_" + format_int(bs) + "_qpP_" + format_int(qp_p) + "_qpQ_" +
@@ -97,7 +97,7 @@ class DeblkLumaTest : public ::testing::TestWithParam<DeblkLumaParam> {
 
   int bs, qp_p, qp_q, beta_offset, tc_offset;
   std::pair<int, int> filter_pair;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int stride, buf_size, src_offset;
   std::vector<UWORD8> src_ref;
   std::vector<UWORD8> src_tst;
@@ -139,13 +139,13 @@ TEST_P(DeblkLumaTest, LumaHorz) {
 // Param: qp_p, qp_q, qp_offset_u, qp_offset_v, tc_offset, filter_pair(p, q),
 // chroma_fmt_idc, arch
 using DeblkChromaParam =
-    std::tuple<int, int, int, int, int, std::pair<int, int>, int, IVD_ARCH_T>;
+    std::tuple<int, int, int, int, int, std::pair<int, int>, int, IV_ARCH_T>;
 
 std::string PrintDeblkChromaParam(
     const testing::TestParamInfo<DeblkChromaParam>& info) {
   int qp_p, qp_q, qp_offset_u, qp_offset_v, tc_offset, chroma_fmt_idc;
   std::pair<int, int> filter_pair;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(qp_p, qp_q, qp_offset_u, qp_offset_v, tc_offset, filter_pair,
            chroma_fmt_idc, arch) = info.param;
   return "qpP_" + format_int(qp_p) + "_qpQ_" + format_int(qp_q) + "_qpU_" +
@@ -184,7 +184,7 @@ class DeblkChromaTest : public ::testing::TestWithParam<DeblkChromaParam> {
 
   int qp_p, qp_q, qp_offset_u, qp_offset_v, tc_offset, chroma_fmt_idc;
   std::pair<int, int> filter_pair;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int stride, buf_size, src_offset;
   std::vector<UWORD8> src_ref;
   std::vector<UWORD8> src_tst;

--- a/tests/common/ihevc_itrans_recon_test.cc
+++ b/tests/common/ihevc_itrans_recon_test.cc
@@ -17,7 +17,7 @@ namespace {
 
 // Test parameters: trans_size, ttype (0: normal, 1: ttype1), arch,
 // non_zero_rows, non_zero_cols (number of non-zero rows/columns)
-using ITransReconTestParam = std::tuple<int, int, IVD_ARCH_T, int, int>;
+using ITransReconTestParam = std::tuple<int, int, IV_ARCH_T, int, int>;
 
 class ITransReconTest : public ::testing::TestWithParam<ITransReconTestParam> {
 protected:
@@ -107,7 +107,7 @@ protected:
 
   int trans_size;
   int ttype;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t *ref_func_selector;
   const func_selector_t *tst_func_selector;
 
@@ -142,7 +142,7 @@ TEST_P(ITransReconTest, Run) {
 std::string PrintITransReconTestParam(
     const testing::TestParamInfo<ITransReconTestParam> &info) {
   WORD32 trans_size, ttype, non_zero_rows, non_zero_cols;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(trans_size, ttype, arch, non_zero_rows, non_zero_cols) = info.param;
   std::stringstream ss;
   ss << "size_" << trans_size << "_ttype_" << ttype << "_nzr_" << non_zero_rows

--- a/tests/common/ihevc_itrans_res_test.cc
+++ b/tests/common/ihevc_itrans_res_test.cc
@@ -37,7 +37,7 @@
 // clang-format on
 
 // Test parameters: trans_size, ttype (0: normal, 1: ttype1), arch
-using ITransResTestParam = std::tuple<int, int, IVD_ARCH_T>;
+using ITransResTestParam = std::tuple<int, int, IV_ARCH_T>;
 
 class ITransResTest : public ::testing::TestWithParam<ITransResTestParam> {
 protected:
@@ -85,7 +85,7 @@ protected:
 
   int trans_size;
   int ttype;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int src_strd, dst_strd;
   std::vector<WORD16> src_buf;
   std::vector<WORD16> tmp_buf;
@@ -114,7 +114,7 @@ TEST_P(ITransResTest, Run) {
 std::string PrintITransResTestParam(
     const testing::TestParamInfo<ITransResTestParam> &info) {
   int trans_size, ttype;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(trans_size, ttype, arch) = info.param;
   std::stringstream ss;
   ss << "size_" << trans_size << "_ttype_" << ttype << "_"

--- a/tests/common/ihevc_itrans_test.cc
+++ b/tests/common/ihevc_itrans_test.cc
@@ -37,7 +37,7 @@ namespace {
 
 // Test parameters: trans_size, ttype (0: normal, 1: ttype1), shift,
 // non_zero_cols, arch
-using ITransTestParam = std::tuple<int, int, int, int, IVD_ARCH_T>;
+using ITransTestParam = std::tuple<int, int, int, int, IV_ARCH_T>;
 
 class ITransTest : public ::testing::TestWithParam<ITransTestParam> {
  protected:
@@ -136,7 +136,7 @@ class ITransTest : public ::testing::TestWithParam<ITransTestParam> {
   int ttype;
   int shift;
   int num_non_zero_cols;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* ref;
   const func_selector_t* tst;
 
@@ -152,7 +152,7 @@ TEST_P(ITransTest, Run) { RunTest(); }
 std::string PrintITransTestParam(
     const testing::TestParamInfo<ITransTestParam>& info) {
   int trans_size, ttype, shift, non_zero_cols;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(trans_size, ttype, shift, non_zero_cols, arch) = info.param;
   std::stringstream ss;
   ss << "size_" << trans_size << "_ttype_" << ttype << "_shift_" << shift

--- a/tests/common/ihevc_luma_inter_pred_test.cc
+++ b/tests/common/ihevc_luma_inter_pred_test.cc
@@ -39,7 +39,7 @@
 // Test parameters: width, height, src_stride_mul, dst_stride_mul, coeff_idx,
 // arch
 using LumaInterPredTestParam =
-    std::tuple<std::pair<int, int>, int, int, int, IVD_ARCH_T>;
+    std::tuple<std::pair<int, int>, int, int, int, IV_ARCH_T>;
 template <typename srcType, typename dstType>
 class LumaInterPredTest
     : public ::testing::TestWithParam<LumaInterPredTestParam> {
@@ -92,7 +92,7 @@ protected:
   dstType *pv_dst_ref;
   dstType *pv_dst_tst;
   WORD8 *pi1_coeffs;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t *tst;
   const func_selector_t *ref;
 };
@@ -151,7 +151,7 @@ auto kLumaInterPredTestParams =
 std::string PrintLumaInterPredTestParam(
     const testing::TestParamInfo<LumaInterPredTestParam> &info) {
   int wd, ht, src_strd_mul, dst_strd_mul, coeff_idx;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::pair<int, int> block_size;
   std::tie(block_size, src_strd_mul, dst_strd_mul, coeff_idx, arch) =
       info.param;

--- a/tests/common/ihevc_luma_intra_pred_test.cc
+++ b/tests/common/ihevc_luma_intra_pred_test.cc
@@ -37,7 +37,7 @@
 // clang-format on
 
 // Test parameters: block_size, mode, dst_stride_mul, arch
-using LumaIntraPredTestParam = std::tuple<int, int, int, IVD_ARCH_T>;
+using LumaIntraPredTestParam = std::tuple<int, int, int, IV_ARCH_T>;
 
 class LumaIntraPredTest
     : public ::testing::TestWithParam<LumaIntraPredTestParam> {
@@ -104,7 +104,7 @@ protected:
   UWORD8 *pu1_ref;
   UWORD8 *pu1_dst_ref;
   UWORD8 *pu1_dst_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t *tst;
   const func_selector_t *ref;
 };
@@ -141,7 +141,7 @@ TEST_P(LumaIntraPredTest, Run) {
 std::string PrintLumaIntraPredTestParam(
     const testing::TestParamInfo<LumaIntraPredTestParam> &info) {
   int nt, mode, dst_strd_mul;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(nt, mode, dst_strd_mul, arch) = info.param;
   std::stringstream ss;
   ss << "nt_" << nt << "_mode_" << mode << "_dst_stride_" << nt * dst_strd_mul

--- a/tests/common/ihevc_mem_fns_test.cc
+++ b/tests/common/ihevc_mem_fns_test.cc
@@ -32,7 +32,7 @@
 namespace {
 
 // Param: offset (0..7 words), num_words, value, arch
-using MemsetTestParam = std::tuple<int, int, UWORD16, IVD_ARCH_T>;
+using MemsetTestParam = std::tuple<int, int, UWORD16, IV_ARCH_T>;
 
 class Memset16BitTest : public ::testing::TestWithParam<MemsetTestParam> {
  protected:
@@ -48,7 +48,7 @@ class Memset16BitTest : public ::testing::TestWithParam<MemsetTestParam> {
   int offset;
   int num_words;
   UWORD16 value;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int buf_size;
   std::vector<UWORD16> dst_ref;
   std::vector<UWORD16> dst_tst;
@@ -80,7 +80,7 @@ class Memset16BitMul8Test : public ::testing::TestWithParam<MemsetTestParam> {
   int offset;
   int num_words;
   UWORD16 value;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int buf_size;
   std::vector<UWORD16> dst_ref;
   std::vector<UWORD16> dst_tst;

--- a/tests/common/ihevc_padding_test.cc
+++ b/tests/common/ihevc_padding_test.cc
@@ -35,13 +35,13 @@ namespace {
 
 // ---------------------------- Test Param -----------------------------------
 
-using PaddingTestParam = std::tuple<std::pair<int, int>, int, IVD_ARCH_T>;
+using PaddingTestParam = std::tuple<std::pair<int, int>, int, IV_ARCH_T>;
 
 std::string PrintPaddingTestParam(
     const testing::TestParamInfo<PaddingTestParam>& info) {
   int wd, ht, pad_size;
   std::pair<int, int> block_size;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(block_size, pad_size, arch) = info.param;
   std::tie(wd, ht) = block_size;
   return std::to_string(wd) + "x" + std::to_string(ht) + "_pad_" +
@@ -83,7 +83,7 @@ class PaddingLumaTest : public ::testing::TestWithParam<PaddingTestParam> {
   }
 
   int wd, ht, pad_size;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int stride, total_ht, buf_size, src_offset;
   std::vector<UWORD8> buf_ref;
   std::vector<UWORD8> buf_tst;
@@ -127,7 +127,7 @@ class PaddingChromaTest : public ::testing::TestWithParam<PaddingTestParam> {
   }
 
   int wd, ht, pad_size;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int stride, total_ht, buf_size, src_offset;
   std::vector<UWORD8> buf_ref;
   std::vector<UWORD8> buf_tst;

--- a/tests/common/ihevc_recon_test.cc
+++ b/tests/common/ihevc_recon_test.cc
@@ -39,7 +39,7 @@ namespace {
 
 // Test parameters: trans_size, ttype (0: normal, 1: ttype1), arch,
 // non_zero_cols
-using ReconTestParam = std::tuple<int, int, IVD_ARCH_T, int>;
+using ReconTestParam = std::tuple<int, int, IV_ARCH_T, int>;
 
 class ReconTest : public ::testing::TestWithParam<ReconTestParam> {
  protected:
@@ -131,7 +131,7 @@ class ReconTest : public ::testing::TestWithParam<ReconTestParam> {
 
   int trans_size;
   int ttype;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* ref;
   const func_selector_t* tst;
 
@@ -164,7 +164,7 @@ TEST_P(ReconTest, Run) {
 std::string PrintReconTestParam(
     const testing::TestParamInfo<ReconTestParam>& info) {
   WORD32 trans_size, ttype, non_zero_cols;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::tie(trans_size, ttype, arch, non_zero_cols) = info.param;
   std::stringstream ss;
   ss << "size_" << trans_size << "_ttype_" << ttype << "_nzc_" << non_zero_cols

--- a/tests/common/ihevc_sao_test.cc
+++ b/tests/common/ihevc_sao_test.cc
@@ -46,12 +46,12 @@ void compare_sao_output(const UWORD8* ref, const UWORD8* tst, int stride,
 // ---------------------------- Test Param -----------------------------------
 
 // Param: block size, sao_band_pos/edge_class (value), arch
-using SaoTestParam = std::tuple<std::pair<int, int>, int, IVD_ARCH_T>;
+using SaoTestParam = std::tuple<std::pair<int, int>, int, IV_ARCH_T>;
 
 std::string PrintSaoTestParam(
     const testing::TestParamInfo<SaoTestParam>& info) {
   int wd, ht, val;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::pair<int, int> block_size;
   std::tie(block_size, val, arch) = info.param;
   std::tie(wd, ht) = block_size;
@@ -138,7 +138,7 @@ class SaoLumaTest : public ::testing::TestWithParam<SaoTestParam> {
   }
 
   int wd, ht, offset_val;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int stride, total_ht, src_size, src_offset;
   std::vector<UWORD8> src_ref;
   std::vector<UWORD8> src_tst;
@@ -241,7 +241,7 @@ class SaoChromaTest : public ::testing::TestWithParam<SaoTestParam> {
   }
 
   int wd, ht, offset_val;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   int stride, total_ht, src_size, src_offset;
   std::vector<UWORD8> src_ref;
   std::vector<UWORD8> src_tst;

--- a/tests/common/ihevc_weighted_pred_test.cc
+++ b/tests/common/ihevc_weighted_pred_test.cc
@@ -43,12 +43,12 @@ namespace {
 // ---------------------------- Param Types ----------------------------------
 
 using WeightedPredTestParam =
-    std::tuple<std::pair<int, int>, int, int, IVD_ARCH_T>;
+    std::tuple<std::pair<int, int>, int, int, IV_ARCH_T>;
 
 std::string PrintWeightedPredTestParam(
     const testing::TestParamInfo<WeightedPredTestParam>& info) {
   int wd, ht, src_strd_mul, dst_strd_mul;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   std::pair<int, int> block_size;
   std::tie(block_size, src_strd_mul, dst_strd_mul, arch) = info.param;
   std::tie(wd, ht) = block_size;
@@ -84,7 +84,7 @@ class WeightedPredUniLumaTest
   std::vector<WORD16> src_buf;
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -145,7 +145,7 @@ class WeightedPredUniChromaTest
   std::vector<WORD16> src_buf;
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -209,7 +209,7 @@ class WeightedPredBiLumaTest
   std::vector<WORD16> src_buf2;
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -276,7 +276,7 @@ class WeightedPredBiChromaTest
   std::vector<WORD16> src_buf2;
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -348,7 +348,7 @@ class WeightedPredBiDefaultLumaTest
   std::vector<WORD16> src_buf2;
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };
@@ -406,7 +406,7 @@ class WeightedPredBiDefaultChromaTest
   std::vector<WORD16> src_buf2;
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
-  IVD_ARCH_T arch;
+  IV_ARCH_T arch;
   const func_selector_t* tst;
   const func_selector_t* ref;
 };

--- a/tests/decoder/DecHelper.cpp
+++ b/tests/decoder/DecHelper.cpp
@@ -69,7 +69,7 @@ static void alignedFree(void* pv_ctxt, void* pv_buf) {
 #endif
 }
 
-static IVD_ARCH_T getDefaultArch() {
+static IV_ARCH_T getDefaultArch() {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
     defined(_M_IX86)
   return ARCH_X86_SSE42;
@@ -83,7 +83,7 @@ static IVD_ARCH_T getDefaultArch() {
 }
 
 // Maps high-level Arch enum to stable native Ittiam API architecture values
-static IVD_ARCH_T getNativeArch(libhevc::test::Arch arch) {
+static IV_ARCH_T getNativeArch(libhevc::test::Arch arch) {
   switch (arch) {
     case libhevc::test::Arch::defaultArch:
       return getDefaultArch();


### PR DESCRIPTION
…SOC_T

This helps in decoupling unit tests in common from depending on ivd.h