### PR TITLE
Add few function selectors in common for modules defined in common.

### DIFF
--- a/common/arm/ihevc_function_selector_a9q.c
+++ b/common/arm/ihevc_function_selector_a9q.c
@@ -1,0 +1,137 @@
+/******************************************************************************
+*
+* Copyright (C) 2026 Ittiam Systems Pvt Ltd, Bangalore
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+/**
+*******************************************************************************
+* @file
+*  ihevc_function_selector_a9q.c
+*
+* @brief
+*  Contains functions to initialize a9q function pointers used in hevc
+*
+* @author
+*  Naveen
+*
+* @par List of Functions:
+* @remarks
+*  None
+*
+*******************************************************************************
+*/
+/*****************************************************************************/
+/* File Includes                                                             */
+/*****************************************************************************/
+#include "ihevc_function_selector.h"
+
+void ihevc_init_function_ptr_a9q(ihevc_func_selector_t *ps_func_selector)
+{
+    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz_a9q;
+    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_a9q;
+    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_a9q;
+    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_w16out_fptr          =  &ihevc_inter_pred_chroma_horz_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_fptr                 =  &ihevc_inter_pred_chroma_vert_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_fptr          =  &ihevc_inter_pred_chroma_vert_w16inp_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr   =  &ihevc_inter_pred_chroma_vert_w16inp_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16out_fptr          =  &ihevc_inter_pred_chroma_vert_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_horz_fptr                   =  &ihevc_inter_pred_luma_horz_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_vert_fptr                   =  &ihevc_inter_pred_luma_vert_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16out_fptr            =  &ihevc_inter_pred_luma_vert_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_fptr            =  &ihevc_inter_pred_luma_vert_w16inp_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_copy_fptr                   =  &ihevc_inter_pred_luma_copy_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_copy_w16out_fptr            =  &ihevc_inter_pred_luma_copy_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_horz_w16out_fptr            =  &ihevc_inter_pred_luma_horz_w16out_a9q;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_w16out_fptr     =  &ihevc_inter_pred_luma_vert_w16inp_w16out_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_substitution_fptr     =  &ihevc_intra_pred_chroma_ref_substitution_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_ref_substitution_fptr       =  &ihevc_intra_pred_luma_ref_substitution_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_ref_subst_all_avlble_fptr   =  &ihevc_intra_pred_luma_ref_subst_all_avlble;
+    ps_func_selector->ihevc_intra_pred_ref_filtering_fptr               =  &ihevc_intra_pred_ref_filtering_neonintr;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_filtering_fptr        =  &ihevc_intra_pred_chroma_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_dc_fptr                   =  &ihevc_intra_pred_chroma_dc_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_horz_fptr                 =  &ihevc_intra_pred_chroma_horz_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_mode2_fptr                =  &ihevc_intra_pred_chroma_mode2_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_18_34_fptr           =  &ihevc_intra_pred_chroma_mode_18_34_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_27_to_33_fptr        =  &ihevc_intra_pred_chroma_mode_27_to_33_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_3_to_9_fptr          =  &ihevc_intra_pred_chroma_mode_3_to_9_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_planar_fptr               =  &ihevc_intra_pred_chroma_planar_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_ver_fptr                  =  &ihevc_intra_pred_chroma_ver_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_11_to_17_fptr        =  &ihevc_intra_pred_chroma_mode_11_to_17_a9q;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_19_to_25_fptr        =  &ihevc_intra_pred_chroma_mode_19_to_25_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_mode_11_to_17_fptr          =  &ihevc_intra_pred_luma_mode_11_to_17_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_mode_19_to_25_fptr          =  &ihevc_intra_pred_luma_mode_19_to_25_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_dc_fptr                     =  &ihevc_intra_pred_luma_dc_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_horz_fptr                   =  &ihevc_intra_pred_luma_horz_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_mode2_fptr                  =  &ihevc_intra_pred_luma_mode2_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_mode_18_34_fptr             =  &ihevc_intra_pred_luma_mode_18_34_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_mode_27_to_33_fptr          =  &ihevc_intra_pred_luma_mode_27_to_33_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_mode_3_to_9_fptr            =  &ihevc_intra_pred_luma_mode_3_to_9_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_planar_fptr                 =  &ihevc_intra_pred_luma_planar_a9q;
+    ps_func_selector->ihevc_intra_pred_luma_ver_fptr                    =  &ihevc_intra_pred_luma_ver_a9q;
+    ps_func_selector->ihevc_itrans_4x4_ttype1_fptr                      =  &ihevc_itrans_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_4x4_fptr                             =  &ihevc_itrans_4x4;
+    ps_func_selector->ihevc_itrans_8x8_fptr                             =  &ihevc_itrans_8x8;
+    ps_func_selector->ihevc_itrans_16x16_fptr                           =  &ihevc_itrans_16x16;
+    ps_func_selector->ihevc_itrans_32x32_fptr                           =  &ihevc_itrans_32x32;
+    ps_func_selector->ihevc_itrans_res_4x4_ttype1_fptr                  =  &ihevc_itrans_res_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_res_4x4_fptr                         =  &ihevc_itrans_res_4x4;
+    ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
+    ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
+    ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_a9q;
+    ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_a9q;
+    ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_a9q;
+    ps_func_selector->ihevc_itrans_recon_16x16_fptr                     =  &ihevc_itrans_recon_16x16_a9q;
+    ps_func_selector->ihevc_itrans_recon_32x32_fptr                     =  &ihevc_itrans_recon_32x32_a9q;
+    ps_func_selector->ihevc_chroma_itrans_recon_4x4_fptr                =  &ihevc_chroma_itrans_recon_4x4;
+    ps_func_selector->ihevc_chroma_itrans_recon_8x8_fptr                =  &ihevc_chroma_itrans_recon_8x8;
+    ps_func_selector->ihevc_chroma_itrans_recon_16x16_fptr              =  &ihevc_chroma_itrans_recon_16x16;
+    ps_func_selector->ihevc_chroma_itrans_recon_32x32_fptr              =  &ihevc_chroma_itrans_recon_32x32;
+    ps_func_selector->ihevc_recon_4x4_ttype1_fptr                       =  &ihevc_recon_4x4_ttype1;
+    ps_func_selector->ihevc_recon_4x4_fptr                              =  &ihevc_recon_4x4;
+    ps_func_selector->ihevc_recon_8x8_fptr                              =  &ihevc_recon_8x8;
+    ps_func_selector->ihevc_recon_16x16_fptr                            =  &ihevc_recon_16x16;
+    ps_func_selector->ihevc_recon_32x32_fptr                            =  &ihevc_recon_32x32;
+    ps_func_selector->ihevc_chroma_recon_4x4_fptr                       =  &ihevc_chroma_recon_4x4;
+    ps_func_selector->ihevc_chroma_recon_8x8_fptr                       =  &ihevc_chroma_recon_8x8;
+    ps_func_selector->ihevc_chroma_recon_16x16_fptr                     =  &ihevc_chroma_recon_16x16;
+    ps_func_selector->ihevc_chroma_recon_32x32_fptr                     =  &ihevc_chroma_recon_32x32;
+    ps_func_selector->ihevc_memset_16bit_mul_8_fptr                     =  &ihevc_memset_16bit_mul_8_a9q;
+    ps_func_selector->ihevc_memset_16bit_fptr                           =  &ihevc_memset_16bit_a9q;
+    ps_func_selector->ihevc_pad_left_luma_fptr                          =  &ihevc_pad_left_luma_a9q;
+    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma_a9q;
+    ps_func_selector->ihevc_pad_right_luma_fptr                         =  &ihevc_pad_right_luma_a9q;
+    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma_a9q;
+    ps_func_selector->ihevc_weighted_pred_bi_fptr                       =  &ihevc_weighted_pred_bi_a9q;
+    ps_func_selector->ihevc_weighted_pred_bi_default_fptr               =  &ihevc_weighted_pred_bi_default_a9q;
+    ps_func_selector->ihevc_weighted_pred_uni_fptr                      =  &ihevc_weighted_pred_uni_a9q;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_fptr                =  &ihevc_weighted_pred_chroma_bi_neonintr;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_default_fptr        =  &ihevc_weighted_pred_chroma_bi_default_neonintr;
+    ps_func_selector->ihevc_weighted_pred_chroma_uni_fptr               =  &ihevc_weighted_pred_chroma_uni_neonintr;
+    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma_a9q;
+    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3_a9q;
+    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma_a9q;
+}

--- a/common/arm/ihevc_intra_ref_substitution_a9q.c
+++ b/common/arm/ihevc_intra_ref_substitution_a9q.c
@@ -18,7 +18,7 @@
 /**
 *******************************************************************************
 * @file
-*  ihevcd_intra_ref_substitution.c
+*  ihevc_intra_ref_substitution.c
 *
 * @brief
 *  Contains ref substitution functions

--- a/common/arm64/ihevc_function_selector_av8.c
+++ b/common/arm64/ihevc_function_selector_av8.c
@@ -1,0 +1,137 @@
+/******************************************************************************
+*
+* Copyright (C) 2026 Ittiam Systems Pvt Ltd, Bangalore
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+/**
+*******************************************************************************
+* @file
+*  ihevc_function_selector.c
+*
+* @brief
+*  Contains functions to initialize a9q function pointers used in hevc
+*
+* @author
+*  Naveen
+*
+* @par List of Functions:
+* @remarks
+*  None
+*
+*******************************************************************************
+*/
+/*****************************************************************************/
+/* File Includes                                                             */
+/*****************************************************************************/
+#include "ihevc_function_selector.h"
+
+void ihevc_init_function_ptr_av8(ihevc_func_selector_t *ps_func_selector)
+{
+    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz_av8;
+    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_av8;
+    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_av8;
+    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_w16out_fptr          =  &ihevc_inter_pred_chroma_horz_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_fptr                 =  &ihevc_inter_pred_chroma_vert_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_fptr          =  &ihevc_inter_pred_chroma_vert_w16inp_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr   =  &ihevc_inter_pred_chroma_vert_w16inp_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16out_fptr          =  &ihevc_inter_pred_chroma_vert_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_luma_horz_fptr                   =  &ihevc_inter_pred_luma_horz_av8;
+    ps_func_selector->ihevc_inter_pred_luma_vert_fptr                   =  &ihevc_inter_pred_luma_vert_av8;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16out_fptr            =  &ihevc_inter_pred_luma_vert_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_fptr            =  &ihevc_inter_pred_luma_vert_w16inp_av8;
+    ps_func_selector->ihevc_inter_pred_luma_copy_fptr                   =  &ihevc_inter_pred_luma_copy_av8;
+    ps_func_selector->ihevc_inter_pred_luma_copy_w16out_fptr            =  &ihevc_inter_pred_luma_copy_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_luma_horz_w16out_fptr            =  &ihevc_inter_pred_luma_horz_w16out_av8;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_w16out_fptr     =  &ihevc_inter_pred_luma_vert_w16inp_w16out_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_substitution_fptr     =  &ihevc_intra_pred_chroma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_substitution_fptr       =  &ihevc_intra_pred_luma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_subst_all_avlble_fptr   =  &ihevc_intra_pred_luma_ref_subst_all_avlble;
+    ps_func_selector->ihevc_intra_pred_ref_filtering_fptr               =  &ihevc_intra_pred_ref_filtering_neonintr;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_filtering_fptr        =  &ihevc_intra_pred_chroma_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_dc_fptr                   =  &ihevc_intra_pred_chroma_dc_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_horz_fptr                 =  &ihevc_intra_pred_chroma_horz_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_mode2_fptr                =  &ihevc_intra_pred_chroma_mode2_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_18_34_fptr           =  &ihevc_intra_pred_chroma_mode_18_34_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_27_to_33_fptr        =  &ihevc_intra_pred_chroma_mode_27_to_33_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_3_to_9_fptr          =  &ihevc_intra_pred_chroma_mode_3_to_9_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_planar_fptr               =  &ihevc_intra_pred_chroma_planar_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_ver_fptr                  =  &ihevc_intra_pred_chroma_ver_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_11_to_17_fptr        =  &ihevc_intra_pred_chroma_mode_11_to_17_av8;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_19_to_25_fptr        =  &ihevc_intra_pred_chroma_mode_19_to_25_av8;
+    ps_func_selector->ihevc_intra_pred_luma_mode_11_to_17_fptr          =  &ihevc_intra_pred_luma_mode_11_to_17_av8;
+    ps_func_selector->ihevc_intra_pred_luma_mode_19_to_25_fptr          =  &ihevc_intra_pred_luma_mode_19_to_25_av8;
+    ps_func_selector->ihevc_intra_pred_luma_dc_fptr                     =  &ihevc_intra_pred_luma_dc_av8;
+    ps_func_selector->ihevc_intra_pred_luma_horz_fptr                   =  &ihevc_intra_pred_luma_horz_av8;
+    ps_func_selector->ihevc_intra_pred_luma_mode2_fptr                  =  &ihevc_intra_pred_luma_mode2_av8;
+    ps_func_selector->ihevc_intra_pred_luma_mode_18_34_fptr             =  &ihevc_intra_pred_luma_mode_18_34_av8;
+    ps_func_selector->ihevc_intra_pred_luma_mode_27_to_33_fptr          =  &ihevc_intra_pred_luma_mode_27_to_33_av8;
+    ps_func_selector->ihevc_intra_pred_luma_mode_3_to_9_fptr            =  &ihevc_intra_pred_luma_mode_3_to_9_av8;
+    ps_func_selector->ihevc_intra_pred_luma_planar_fptr                 =  &ihevc_intra_pred_luma_planar_av8;
+    ps_func_selector->ihevc_intra_pred_luma_ver_fptr                    =  &ihevc_intra_pred_luma_ver_av8;
+    ps_func_selector->ihevc_itrans_4x4_ttype1_fptr                      =  &ihevc_itrans_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_4x4_fptr                             =  &ihevc_itrans_4x4;
+    ps_func_selector->ihevc_itrans_8x8_fptr                             =  &ihevc_itrans_8x8;
+    ps_func_selector->ihevc_itrans_16x16_fptr                           =  &ihevc_itrans_16x16;
+    ps_func_selector->ihevc_itrans_32x32_fptr                           =  &ihevc_itrans_32x32;
+    ps_func_selector->ihevc_itrans_res_4x4_ttype1_fptr                  =  &ihevc_itrans_res_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_res_4x4_fptr                         =  &ihevc_itrans_res_4x4;
+    ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
+    ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
+    ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_av8;
+    ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_av8;
+    ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_av8;
+    ps_func_selector->ihevc_itrans_recon_16x16_fptr                     =  &ihevc_itrans_recon_16x16_av8;
+    ps_func_selector->ihevc_itrans_recon_32x32_fptr                     =  &ihevc_itrans_recon_32x32_av8;
+    ps_func_selector->ihevc_chroma_itrans_recon_4x4_fptr                =  &ihevc_chroma_itrans_recon_4x4;
+    ps_func_selector->ihevc_chroma_itrans_recon_8x8_fptr                =  &ihevc_chroma_itrans_recon_8x8;
+    ps_func_selector->ihevc_chroma_itrans_recon_16x16_fptr              =  &ihevc_chroma_itrans_recon_16x16;
+    ps_func_selector->ihevc_chroma_itrans_recon_32x32_fptr              =  &ihevc_chroma_itrans_recon_32x32;
+    ps_func_selector->ihevc_recon_4x4_ttype1_fptr                       =  &ihevc_recon_4x4_ttype1;
+    ps_func_selector->ihevc_recon_4x4_fptr                              =  &ihevc_recon_4x4;
+    ps_func_selector->ihevc_recon_8x8_fptr                              =  &ihevc_recon_8x8;
+    ps_func_selector->ihevc_recon_16x16_fptr                            =  &ihevc_recon_16x16;
+    ps_func_selector->ihevc_recon_32x32_fptr                            =  &ihevc_recon_32x32;
+    ps_func_selector->ihevc_chroma_recon_4x4_fptr                       =  &ihevc_chroma_recon_4x4;
+    ps_func_selector->ihevc_chroma_recon_8x8_fptr                       =  &ihevc_chroma_recon_8x8;
+    ps_func_selector->ihevc_chroma_recon_16x16_fptr                     =  &ihevc_chroma_recon_16x16;
+    ps_func_selector->ihevc_chroma_recon_32x32_fptr                     =  &ihevc_chroma_recon_32x32;
+    ps_func_selector->ihevc_memset_16bit_mul_8_fptr                     =  &ihevc_memset_16bit_mul_8_av8;
+    ps_func_selector->ihevc_memset_16bit_fptr                           =  &ihevc_memset_16bit_av8;
+    ps_func_selector->ihevc_pad_left_luma_fptr                          =  &ihevc_pad_left_luma_av8;
+    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma_av8;
+    ps_func_selector->ihevc_pad_right_luma_fptr                         =  &ihevc_pad_right_luma_av8;
+    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma_av8;
+    ps_func_selector->ihevc_weighted_pred_bi_fptr                       =  &ihevc_weighted_pred_bi_av8;
+    ps_func_selector->ihevc_weighted_pred_bi_default_fptr               =  &ihevc_weighted_pred_bi_default_av8;
+    ps_func_selector->ihevc_weighted_pred_uni_fptr                      =  &ihevc_weighted_pred_uni_av8;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_fptr                =  &ihevc_weighted_pred_chroma_bi_neonintr;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_default_fptr        =  &ihevc_weighted_pred_chroma_bi_default_neonintr;
+    ps_func_selector->ihevc_weighted_pred_chroma_uni_fptr               =  &ihevc_weighted_pred_chroma_uni_neonintr;
+    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma_av8;
+    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3_av8;
+    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma_av8;
+}

--- a/common/common.cmake
+++ b/common/common.cmake
@@ -59,7 +59,8 @@ list(
   "${HEVC_ROOT}/common/ihevc_resi_trans.c"
   "${HEVC_ROOT}/common/ihevc_sao.c"
   "${HEVC_ROOT}/common/ihevc_trans_tables.c"
-  "${HEVC_ROOT}/common/ihevc_weighted_pred.c")
+  "${HEVC_ROOT}/common/ihevc_weighted_pred.c"
+  "${HEVC_ROOT}/common/ihevc_function_selector_generic.c")
 
 include_directories(${HEVC_ROOT}/common)
 
@@ -134,7 +135,9 @@ if("${SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${SYSTEM_PROCESSOR}" STREQUAL "a
     "${HEVC_ROOT}/common/arm64/ihevc_sao_edge_offset_class3.s"
     "${HEVC_ROOT}/common/arm64/ihevc_weighted_pred_bi_default.s"
     "${HEVC_ROOT}/common/arm64/ihevc_weighted_pred_bi.s"
-    "${HEVC_ROOT}/common/arm64/ihevc_weighted_pred_uni.s")
+    "${HEVC_ROOT}/common/arm64/ihevc_weighted_pred_uni.s"
+    "${HEVC_ROOT}/common/arm64/ihevc_function_selector_av8.c"
+    "${HEVC_ROOT}/common/arm/ihevc_function_selector_a9q.c")
 
   include_directories(${HEVC_ROOT}/common/arm64 ${HEVC_ROOT}/common/arm)
 elseif("${SYSTEM_PROCESSOR}" STREQUAL "aarch32")
@@ -209,7 +212,8 @@ elseif("${SYSTEM_PROCESSOR}" STREQUAL "aarch32")
     "${HEVC_ROOT}/common/arm/ihevc_weighted_pred_bi_default.s"
     "${HEVC_ROOT}/common/arm/ihevc_weighted_pred_bi.s"
     "${HEVC_ROOT}/common/arm/ihevc_weighted_pred_neon_intr.c"
-    "${HEVC_ROOT}/common/arm/ihevc_weighted_pred_uni.s")
+    "${HEVC_ROOT}/common/arm/ihevc_weighted_pred_uni.s"
+    "${HEVC_ROOT}/common/arm/ihevc_function_selector_a9q.c")
 
   include_directories(${HEVC_ROOT}/common/arm)
 else()
@@ -234,7 +238,9 @@ else()
     "${HEVC_ROOT}/common/x86/ihevc_itrans_recon_sse42_intr.c"
     "${HEVC_ROOT}/common/x86/ihevc_16x16_itrans_recon_sse42_intr.c"
     "${HEVC_ROOT}/common/x86/ihevc_32x32_itrans_recon_sse42_intr.c"
-    "${HEVC_ROOT}/common/x86/ihevc_tables_x86_intr.c")
+    "${HEVC_ROOT}/common/x86/ihevc_tables_x86_intr.c"
+    "${HEVC_ROOT}/common/x86/ihevc_function_selector_sse42.c"
+    "${HEVC_ROOT}/common/x86/ihevc_function_selector_ssse3.c")
 
   include_directories(${HEVC_ROOT}/common/x86)
 endif()

--- a/common/ihevc_function_selector.h
+++ b/common/ihevc_function_selector.h
@@ -1,0 +1,179 @@
+/******************************************************************************
+*
+* Copyright (C) 2026 Ittiam Systems Pvt Ltd, Bangalore
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+
+/**
+ *******************************************************************************
+ * @file
+ *  ihevc_function_selector.h
+ *
+ * @brief
+ *  Structure definitions used in the decoder
+ *
+ * @author
+ *  Harish
+ *
+ * @par List of Functions:
+ *
+ * @remarks
+ *  None
+ *
+ *******************************************************************************
+ */
+
+#ifndef _IHEVC_FUNCTION_SELECTOR_H_
+#define _IHEVC_FUNCTION_SELECTOR_H_
+#include "ihevc_typedefs.h"
+#include "ihevc_deblk.h"
+#include "ihevc_itrans.h"
+#include "ihevc_itrans_res.h"
+#include "ihevc_itrans_recon.h"
+#include "ihevc_chroma_itrans_recon.h"
+#include "ihevc_chroma_intra_pred.h"
+#include "ihevc_recon.h"
+#include "ihevc_chroma_recon.h"
+#include "ihevc_intra_pred.h"
+#include "ihevc_inter_pred.h"
+#include "ihevc_mem_fns.h"
+#include "ihevc_padding.h"
+#include "ihevc_weighted_pred.h"
+#include "ihevc_sao.h"
+
+typedef struct
+{
+    ihevc_deblk_chroma_horz_ft *ihevc_deblk_chroma_horz_fptr;
+    ihevc_deblk_chroma_vert_ft *ihevc_deblk_chroma_vert_fptr;
+    ihevc_deblk_luma_vert_ft *ihevc_deblk_luma_vert_fptr;
+    ihevc_deblk_luma_horz_ft *ihevc_deblk_luma_horz_fptr;
+    ihevc_deblk_chroma_horz_ft *ihevc_deblk_422chroma_horz_fptr;
+    ihevc_deblk_chroma_vert_ft *ihevc_deblk_422chroma_vert_fptr;
+
+    ihevc_inter_pred_ft *ihevc_inter_pred_chroma_copy_fptr;
+    ihevc_inter_pred_w16out_ft *ihevc_inter_pred_chroma_copy_w16out_fptr;
+    ihevc_inter_pred_ft *ihevc_inter_pred_chroma_horz_fptr;
+    ihevc_inter_pred_w16out_ft *ihevc_inter_pred_chroma_horz_w16out_fptr;
+    ihevc_inter_pred_ft *ihevc_inter_pred_chroma_vert_fptr;
+    ihevc_inter_pred_w16inp_ft *ihevc_inter_pred_chroma_vert_w16inp_fptr;
+    ihevc_inter_pred_w16inp_w16out_ft *ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr;
+    ihevc_inter_pred_w16out_ft *ihevc_inter_pred_chroma_vert_w16out_fptr;
+    ihevc_inter_pred_ft *ihevc_inter_pred_luma_horz_fptr;
+    ihevc_inter_pred_ft *ihevc_inter_pred_luma_vert_fptr;
+    ihevc_inter_pred_w16out_ft *ihevc_inter_pred_luma_vert_w16out_fptr;
+    ihevc_inter_pred_w16inp_ft *ihevc_inter_pred_luma_vert_w16inp_fptr;
+    ihevc_inter_pred_ft *ihevc_inter_pred_luma_copy_fptr;
+    ihevc_inter_pred_w16out_ft *ihevc_inter_pred_luma_copy_w16out_fptr;
+    ihevc_inter_pred_w16out_ft *ihevc_inter_pred_luma_horz_w16out_fptr;
+    ihevc_inter_pred_w16inp_w16out_ft *ihevc_inter_pred_luma_vert_w16inp_w16out_fptr;
+
+    ihevc_intra_pred_chroma_ref_substitution_ft *ihevc_intra_pred_chroma_ref_substitution_fptr;
+    ihevc_intra_pred_luma_ref_substitution_ft *ihevc_intra_pred_luma_ref_substitution_fptr;
+    ihevc_intra_pred_luma_ref_subst_all_avlble_ft *ihevc_intra_pred_luma_ref_subst_all_avlble_fptr;
+    ihevc_intra_pred_ref_filtering_ft *ihevc_intra_pred_ref_filtering_fptr;
+    ihevc_intra_pred_chroma_ref_filtering_ft *ihevc_intra_pred_chroma_ref_filtering_fptr;
+    ihevc_intra_pred_chroma_dc_ft *ihevc_intra_pred_chroma_dc_fptr;
+    ihevc_intra_pred_chroma_horz_ft *ihevc_intra_pred_chroma_horz_fptr;
+    ihevc_intra_pred_chroma_mode2_ft *ihevc_intra_pred_chroma_mode2_fptr;
+    ihevc_intra_pred_chroma_mode_18_34_ft *ihevc_intra_pred_chroma_mode_18_34_fptr;
+    ihevc_intra_pred_chroma_mode_27_to_33_ft *ihevc_intra_pred_chroma_mode_27_to_33_fptr;
+    ihevc_intra_pred_chroma_mode_3_to_9_ft *ihevc_intra_pred_chroma_mode_3_to_9_fptr;
+    ihevc_intra_pred_chroma_planar_ft *ihevc_intra_pred_chroma_planar_fptr;
+    ihevc_intra_pred_chroma_ver_ft *ihevc_intra_pred_chroma_ver_fptr;
+    ihevc_intra_pred_chroma_mode_11_to_17_ft *ihevc_intra_pred_chroma_mode_11_to_17_fptr;
+    ihevc_intra_pred_chroma_mode_19_to_25_ft *ihevc_intra_pred_chroma_mode_19_to_25_fptr;
+    ihevc_intra_pred_luma_mode_11_to_17_ft *ihevc_intra_pred_luma_mode_11_to_17_fptr;
+    ihevc_intra_pred_luma_mode_19_to_25_ft *ihevc_intra_pred_luma_mode_19_to_25_fptr;
+    ihevc_intra_pred_luma_dc_ft *ihevc_intra_pred_luma_dc_fptr;
+    ihevc_intra_pred_luma_horz_ft *ihevc_intra_pred_luma_horz_fptr;
+    ihevc_intra_pred_luma_mode2_ft *ihevc_intra_pred_luma_mode2_fptr;
+    ihevc_intra_pred_luma_mode_18_34_ft *ihevc_intra_pred_luma_mode_18_34_fptr;
+    ihevc_intra_pred_luma_mode_27_to_33_ft *ihevc_intra_pred_luma_mode_27_to_33_fptr;
+    ihevc_intra_pred_luma_mode_3_to_9_ft *ihevc_intra_pred_luma_mode_3_to_9_fptr;
+    ihevc_intra_pred_luma_planar_ft *ihevc_intra_pred_luma_planar_fptr;
+    ihevc_intra_pred_luma_ver_ft *ihevc_intra_pred_luma_ver_fptr;
+    ihevc_itrans_4x4_ttype1_ft *ihevc_itrans_4x4_ttype1_fptr;
+    ihevc_itrans_4x4_ft *ihevc_itrans_4x4_fptr;
+    ihevc_itrans_8x8_ft *ihevc_itrans_8x8_fptr;
+    ihevc_itrans_16x16_ft *ihevc_itrans_16x16_fptr;
+    ihevc_itrans_32x32_ft *ihevc_itrans_32x32_fptr;
+    ihevc_itrans_res_4x4_ttype1_ft *ihevc_itrans_res_4x4_ttype1_fptr;
+    ihevc_itrans_res_4x4_ft *ihevc_itrans_res_4x4_fptr;
+    ihevc_itrans_res_8x8_ft *ihevc_itrans_res_8x8_fptr;
+    ihevc_itrans_res_16x16_ft *ihevc_itrans_res_16x16_fptr;
+    ihevc_itrans_res_32x32_ft *ihevc_itrans_res_32x32_fptr;
+    ihevc_itrans_recon_4x4_ttype1_ft *ihevc_itrans_recon_4x4_ttype1_fptr;
+    ihevc_itrans_recon_4x4_ft *ihevc_itrans_recon_4x4_fptr;
+    ihevc_itrans_recon_8x8_ft *ihevc_itrans_recon_8x8_fptr;
+    ihevc_itrans_recon_16x16_ft *ihevc_itrans_recon_16x16_fptr;
+    ihevc_itrans_recon_32x32_ft *ihevc_itrans_recon_32x32_fptr;
+    ihevc_chroma_itrans_recon_4x4_ft *ihevc_chroma_itrans_recon_4x4_fptr;
+    ihevc_chroma_itrans_recon_8x8_ft *ihevc_chroma_itrans_recon_8x8_fptr;
+    ihevc_chroma_itrans_recon_16x16_ft *ihevc_chroma_itrans_recon_16x16_fptr;
+    ihevc_chroma_itrans_recon_32x32_ft *ihevc_chroma_itrans_recon_32x32_fptr;
+    ihevc_recon_4x4_ttype1_ft *ihevc_recon_4x4_ttype1_fptr;
+    ihevc_recon_4x4_ft *ihevc_recon_4x4_fptr;
+    ihevc_recon_8x8_ft *ihevc_recon_8x8_fptr;
+    ihevc_recon_16x16_ft *ihevc_recon_16x16_fptr;
+    ihevc_recon_32x32_ft *ihevc_recon_32x32_fptr;
+    ihevc_chroma_recon_4x4_ft *ihevc_chroma_recon_4x4_fptr;
+    ihevc_chroma_recon_8x8_ft *ihevc_chroma_recon_8x8_fptr;
+    ihevc_chroma_recon_16x16_ft *ihevc_chroma_recon_16x16_fptr;
+    ihevc_chroma_recon_32x32_ft *ihevc_chroma_recon_32x32_fptr;
+    ihevc_memset_16bit_mul_8_ft *ihevc_memset_16bit_mul_8_fptr;
+    ihevc_memset_16bit_ft *ihevc_memset_16bit_fptr;
+    ihevc_pad_left_luma_ft *ihevc_pad_left_luma_fptr;
+    ihevc_pad_left_chroma_ft *ihevc_pad_left_chroma_fptr;
+    ihevc_pad_right_luma_ft *ihevc_pad_right_luma_fptr;
+    ihevc_pad_right_chroma_ft *ihevc_pad_right_chroma_fptr;
+    ihevc_weighted_pred_bi_ft *ihevc_weighted_pred_bi_fptr;
+    ihevc_weighted_pred_bi_default_ft *ihevc_weighted_pred_bi_default_fptr;
+    ihevc_weighted_pred_uni_ft *ihevc_weighted_pred_uni_fptr;
+    ihevc_weighted_pred_chroma_bi_ft *ihevc_weighted_pred_chroma_bi_fptr;
+    ihevc_weighted_pred_chroma_bi_default_ft *ihevc_weighted_pred_chroma_bi_default_fptr;
+    ihevc_weighted_pred_chroma_uni_ft *ihevc_weighted_pred_chroma_uni_fptr;
+    ihevc_sao_band_offset_luma_ft *ihevc_sao_band_offset_luma_fptr;
+    ihevc_sao_band_offset_chroma_ft *ihevc_sao_band_offset_chroma_fptr;
+    ihevc_sao_edge_offset_class0_ft *ihevc_sao_edge_offset_class0_fptr;
+    ihevc_sao_edge_offset_class0_chroma_ft *ihevc_sao_edge_offset_class0_chroma_fptr;
+    ihevc_sao_edge_offset_class1_ft *ihevc_sao_edge_offset_class1_fptr;
+    ihevc_sao_edge_offset_class1_chroma_ft *ihevc_sao_edge_offset_class1_chroma_fptr;
+    ihevc_sao_edge_offset_class2_ft *ihevc_sao_edge_offset_class2_fptr;
+    ihevc_sao_edge_offset_class2_chroma_ft *ihevc_sao_edge_offset_class2_chroma_fptr;
+    ihevc_sao_edge_offset_class3_ft *ihevc_sao_edge_offset_class3_fptr;
+    ihevc_sao_edge_offset_class3_chroma_ft *ihevc_sao_edge_offset_class3_chroma_fptr;
+}ihevc_func_selector_t;
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void ihevc_init_function_ptr_generic(ihevc_func_selector_t *ps_func_selector);
+void ihevc_init_function_ptr_ssse3(ihevc_func_selector_t *ps_func_selector);
+void ihevc_init_function_ptr_sse42(ihevc_func_selector_t *ps_func_selector);
+
+#ifndef DISABLE_AVX2
+void ihevc_init_function_ptr_avx2(ihevc_func_selector_t *ps_func_selector);
+#endif
+
+void ihevc_init_function_ptr_neonintr(ihevc_func_selector_t *ps_func_selector);
+void ihevc_init_function_ptr_a9q(ihevc_func_selector_t *ps_func_selector);
+void ihevc_init_function_ptr_av8(ihevc_func_selector_t *ps_func_selector);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _IHEVC_FUNCTION_SELECTOR_H_ */

--- a/common/ihevc_function_selector_generic.c
+++ b/common/ihevc_function_selector_generic.c
@@ -1,0 +1,139 @@
+/******************************************************************************
+*
+* Copyright (C) 2026 Ittiam Systems Pvt Ltd, Bangalore
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+/**
+*******************************************************************************
+* @file
+*  ihevc_function_selector.c
+*
+* @brief
+*  Contains functions to initialize function pointers used in hevc
+*
+* @author
+*  Naveen
+*
+* @par List of Functions:
+* @remarks
+*  None
+*
+*******************************************************************************
+*/
+/*****************************************************************************/
+/* File Includes                                                             */
+/*****************************************************************************/
+#include "ihevc_function_selector.h"
+
+void ihevc_init_function_ptr_generic(ihevc_func_selector_t *ps_func_selector)
+{
+    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz;
+    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert;
+    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert;
+    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_w16out_fptr          =  &ihevc_inter_pred_chroma_horz_w16out;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_fptr                 =  &ihevc_inter_pred_chroma_vert;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_fptr          =  &ihevc_inter_pred_chroma_vert_w16inp;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr   =  &ihevc_inter_pred_chroma_vert_w16inp_w16out;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16out_fptr          =  &ihevc_inter_pred_chroma_vert_w16out;
+    ps_func_selector->ihevc_inter_pred_luma_horz_fptr                   =  &ihevc_inter_pred_luma_horz;
+    ps_func_selector->ihevc_inter_pred_luma_vert_fptr                   =  &ihevc_inter_pred_luma_vert;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16out_fptr            =  &ihevc_inter_pred_luma_vert_w16out;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_fptr            =  &ihevc_inter_pred_luma_vert_w16inp;
+    ps_func_selector->ihevc_inter_pred_luma_copy_fptr                   =  &ihevc_inter_pred_luma_copy;
+    ps_func_selector->ihevc_inter_pred_luma_copy_w16out_fptr            =  &ihevc_inter_pred_luma_copy_w16out;
+    ps_func_selector->ihevc_inter_pred_luma_horz_w16out_fptr            =  &ihevc_inter_pred_luma_horz_w16out;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_w16out_fptr     =  &ihevc_inter_pred_luma_vert_w16inp_w16out;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_substitution_fptr     =  &ihevc_intra_pred_chroma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_substitution_fptr       =  &ihevc_intra_pred_luma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_subst_all_avlble_fptr   =  &ihevc_intra_pred_luma_ref_subst_all_avlble;
+    ps_func_selector->ihevc_intra_pred_ref_filtering_fptr               =  &ihevc_intra_pred_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_filtering_fptr        =  &ihevc_intra_pred_chroma_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_dc_fptr                   =  &ihevc_intra_pred_chroma_dc;
+    ps_func_selector->ihevc_intra_pred_chroma_horz_fptr                 =  &ihevc_intra_pred_chroma_horz;
+    ps_func_selector->ihevc_intra_pred_chroma_mode2_fptr                =  &ihevc_intra_pred_chroma_mode2;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_18_34_fptr           =  &ihevc_intra_pred_chroma_mode_18_34;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_27_to_33_fptr        =  &ihevc_intra_pred_chroma_mode_27_to_33;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_3_to_9_fptr          =  &ihevc_intra_pred_chroma_mode_3_to_9;
+    ps_func_selector->ihevc_intra_pred_chroma_planar_fptr               =  &ihevc_intra_pred_chroma_planar;
+    ps_func_selector->ihevc_intra_pred_chroma_ver_fptr                  =  &ihevc_intra_pred_chroma_ver;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_11_to_17_fptr        =  &ihevc_intra_pred_chroma_mode_11_to_17;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_19_to_25_fptr        =  &ihevc_intra_pred_chroma_mode_19_to_25;
+    ps_func_selector->ihevc_intra_pred_luma_mode_11_to_17_fptr          =  &ihevc_intra_pred_luma_mode_11_to_17;
+    ps_func_selector->ihevc_intra_pred_luma_mode_19_to_25_fptr          =  &ihevc_intra_pred_luma_mode_19_to_25;
+    ps_func_selector->ihevc_intra_pred_luma_dc_fptr                     =  &ihevc_intra_pred_luma_dc;
+    ps_func_selector->ihevc_intra_pred_luma_horz_fptr                   =  &ihevc_intra_pred_luma_horz;
+    ps_func_selector->ihevc_intra_pred_luma_mode2_fptr                  =  &ihevc_intra_pred_luma_mode2;
+    ps_func_selector->ihevc_intra_pred_luma_mode_18_34_fptr             =  &ihevc_intra_pred_luma_mode_18_34;
+    ps_func_selector->ihevc_intra_pred_luma_mode_27_to_33_fptr          =  &ihevc_intra_pred_luma_mode_27_to_33;
+    ps_func_selector->ihevc_intra_pred_luma_mode_3_to_9_fptr            =  &ihevc_intra_pred_luma_mode_3_to_9;
+    ps_func_selector->ihevc_intra_pred_luma_planar_fptr                 =  &ihevc_intra_pred_luma_planar;
+    ps_func_selector->ihevc_intra_pred_luma_ver_fptr                    =  &ihevc_intra_pred_luma_ver;
+    ps_func_selector->ihevc_itrans_4x4_ttype1_fptr                      =  &ihevc_itrans_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_4x4_fptr                             =  &ihevc_itrans_4x4;
+    ps_func_selector->ihevc_itrans_8x8_fptr                             =  &ihevc_itrans_8x8;
+    ps_func_selector->ihevc_itrans_16x16_fptr                           =  &ihevc_itrans_16x16;
+    ps_func_selector->ihevc_itrans_32x32_fptr                           =  &ihevc_itrans_32x32;
+    ps_func_selector->ihevc_itrans_res_4x4_ttype1_fptr                  =  &ihevc_itrans_res_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_res_4x4_fptr                         =  &ihevc_itrans_res_4x4;
+    ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
+    ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
+    ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4;
+    ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8;
+    ps_func_selector->ihevc_itrans_recon_16x16_fptr                     =  &ihevc_itrans_recon_16x16;
+    ps_func_selector->ihevc_itrans_recon_32x32_fptr                     =  &ihevc_itrans_recon_32x32;
+    ps_func_selector->ihevc_chroma_itrans_recon_4x4_fptr                =  &ihevc_chroma_itrans_recon_4x4;
+    ps_func_selector->ihevc_chroma_itrans_recon_8x8_fptr                =  &ihevc_chroma_itrans_recon_8x8;
+    ps_func_selector->ihevc_chroma_itrans_recon_16x16_fptr              =  &ihevc_chroma_itrans_recon_16x16;
+    ps_func_selector->ihevc_chroma_itrans_recon_32x32_fptr              =  &ihevc_chroma_itrans_recon_32x32;
+    ps_func_selector->ihevc_recon_4x4_ttype1_fptr                       =  &ihevc_recon_4x4_ttype1;
+    ps_func_selector->ihevc_recon_4x4_fptr                              =  &ihevc_recon_4x4;
+    ps_func_selector->ihevc_recon_8x8_fptr                              =  &ihevc_recon_8x8;
+    ps_func_selector->ihevc_recon_16x16_fptr                            =  &ihevc_recon_16x16;
+    ps_func_selector->ihevc_recon_32x32_fptr                            =  &ihevc_recon_32x32;
+    ps_func_selector->ihevc_chroma_recon_4x4_fptr                       =  &ihevc_chroma_recon_4x4;
+    ps_func_selector->ihevc_chroma_recon_8x8_fptr                       =  &ihevc_chroma_recon_8x8;
+    ps_func_selector->ihevc_chroma_recon_16x16_fptr                     =  &ihevc_chroma_recon_16x16;
+    ps_func_selector->ihevc_chroma_recon_32x32_fptr                     =  &ihevc_chroma_recon_32x32;
+    ps_func_selector->ihevc_memset_16bit_mul_8_fptr                     =  &ihevc_memset_16bit_mul_8;
+    ps_func_selector->ihevc_memset_16bit_fptr                           =  &ihevc_memset_16bit;
+    ps_func_selector->ihevc_pad_left_luma_fptr                          =  &ihevc_pad_left_luma;
+    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma;
+    ps_func_selector->ihevc_pad_right_luma_fptr                         =  &ihevc_pad_right_luma;
+    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma;
+    ps_func_selector->ihevc_weighted_pred_bi_fptr                       =  &ihevc_weighted_pred_bi;
+    ps_func_selector->ihevc_weighted_pred_bi_default_fptr               =  &ihevc_weighted_pred_bi_default;
+    ps_func_selector->ihevc_weighted_pred_uni_fptr                      =  &ihevc_weighted_pred_uni;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_fptr                =  &ihevc_weighted_pred_chroma_bi;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_default_fptr        =  &ihevc_weighted_pred_chroma_bi_default;
+    ps_func_selector->ihevc_weighted_pred_chroma_uni_fptr               =  &ihevc_weighted_pred_chroma_uni;
+    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma;
+    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0;
+    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1;
+    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2;
+    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3;
+    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma;
+}

--- a/common/x86/ihevc_function_selector_sse42.c
+++ b/common/x86/ihevc_function_selector_sse42.c
@@ -1,0 +1,137 @@
+/******************************************************************************
+*
+* Copyright (C) 2026 Ittiam Systems Pvt Ltd, Bangalore
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+/**
+*******************************************************************************
+* @file
+*  ihevc_function_selector_sse42.c
+*
+* @brief
+*  Contains functions to initialize function pointers used in hevc
+*
+* @author
+*  Naveen
+*
+* @par List of Functions:
+* @remarks
+*  None
+*
+*******************************************************************************
+*/
+/*****************************************************************************/
+/* File Includes                                                             */
+/*****************************************************************************/
+#include "ihevc_function_selector.h"
+
+void ihevc_init_function_ptr_sse42(ihevc_func_selector_t *ps_func_selector)
+{
+    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz_ssse3;
+    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_ssse3;
+    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_ssse3;
+    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_sse42;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_sse42;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_w16out_fptr          =  &ihevc_inter_pred_chroma_horz_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_fptr                 =  &ihevc_inter_pred_chroma_vert_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_fptr          =  &ihevc_inter_pred_chroma_vert_w16inp_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr   =  &ihevc_inter_pred_chroma_vert_w16inp_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16out_fptr          =  &ihevc_inter_pred_chroma_vert_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_horz_fptr                   =  &ihevc_inter_pred_luma_horz_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_fptr                   =  &ihevc_inter_pred_luma_vert_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16out_fptr            =  &ihevc_inter_pred_luma_vert_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_fptr            =  &ihevc_inter_pred_luma_vert_w16inp_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_copy_fptr                   =  &ihevc_inter_pred_luma_copy_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_copy_w16out_fptr            =  &ihevc_inter_pred_luma_copy_w16out_sse42;
+    ps_func_selector->ihevc_inter_pred_luma_horz_w16out_fptr            =  &ihevc_inter_pred_luma_horz_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_w16out_fptr     =  &ihevc_inter_pred_luma_vert_w16inp_w16out_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_substitution_fptr     =  &ihevc_intra_pred_chroma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_substitution_fptr       =  &ihevc_intra_pred_luma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_subst_all_avlble_fptr   =  &ihevc_intra_pred_luma_ref_subst_all_avlble;
+    ps_func_selector->ihevc_intra_pred_ref_filtering_fptr               =  &ihevc_intra_pred_ref_filtering_sse42;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_filtering_fptr        =  &ihevc_intra_pred_chroma_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_dc_fptr                   =  &ihevc_intra_pred_chroma_dc_sse42;
+    ps_func_selector->ihevc_intra_pred_chroma_horz_fptr                 =  &ihevc_intra_pred_chroma_horz_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode2_fptr                =  &ihevc_intra_pred_chroma_mode2_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_18_34_fptr           =  &ihevc_intra_pred_chroma_mode_18_34_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_27_to_33_fptr        =  &ihevc_intra_pred_chroma_mode_27_to_33_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_3_to_9_fptr          =  &ihevc_intra_pred_chroma_mode_3_to_9_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_planar_fptr               =  &ihevc_intra_pred_chroma_planar_sse42;
+    ps_func_selector->ihevc_intra_pred_chroma_ver_fptr                  =  &ihevc_intra_pred_chroma_ver_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_11_to_17_fptr        =  &ihevc_intra_pred_chroma_mode_11_to_17_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_19_to_25_fptr        =  &ihevc_intra_pred_chroma_mode_19_to_25_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_11_to_17_fptr          =  &ihevc_intra_pred_luma_mode_11_to_17_sse42;
+    ps_func_selector->ihevc_intra_pred_luma_mode_19_to_25_fptr          =  &ihevc_intra_pred_luma_mode_19_to_25_sse42;
+    ps_func_selector->ihevc_intra_pred_luma_dc_fptr                     =  &ihevc_intra_pred_luma_dc_sse42;
+    ps_func_selector->ihevc_intra_pred_luma_horz_fptr                   =  &ihevc_intra_pred_luma_horz_sse42;
+    ps_func_selector->ihevc_intra_pred_luma_mode2_fptr                  =  &ihevc_intra_pred_luma_mode2_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_18_34_fptr             =  &ihevc_intra_pred_luma_mode_18_34_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_27_to_33_fptr          =  &ihevc_intra_pred_luma_mode_27_to_33_sse42;
+    ps_func_selector->ihevc_intra_pred_luma_mode_3_to_9_fptr            =  &ihevc_intra_pred_luma_mode_3_to_9_sse42;
+    ps_func_selector->ihevc_intra_pred_luma_planar_fptr                 =  &ihevc_intra_pred_luma_planar_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_ver_fptr                    =  &ihevc_intra_pred_luma_ver_sse42;
+    ps_func_selector->ihevc_itrans_4x4_ttype1_fptr                      =  &ihevc_itrans_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_4x4_fptr                             =  &ihevc_itrans_4x4;
+    ps_func_selector->ihevc_itrans_8x8_fptr                             =  &ihevc_itrans_8x8;
+    ps_func_selector->ihevc_itrans_16x16_fptr                           =  &ihevc_itrans_16x16;
+    ps_func_selector->ihevc_itrans_32x32_fptr                           =  &ihevc_itrans_32x32;
+    ps_func_selector->ihevc_itrans_res_4x4_ttype1_fptr                  =  &ihevc_itrans_res_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_res_4x4_fptr                         =  &ihevc_itrans_res_4x4;
+    ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
+    ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
+    ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_sse42;
+    ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_sse42;
+    ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_sse42;
+    ps_func_selector->ihevc_itrans_recon_16x16_fptr                     =  &ihevc_itrans_recon_16x16_ssse3;
+    ps_func_selector->ihevc_itrans_recon_32x32_fptr                     =  &ihevc_itrans_recon_32x32_sse42;
+    ps_func_selector->ihevc_chroma_itrans_recon_4x4_fptr                =  &ihevc_chroma_itrans_recon_4x4;
+    ps_func_selector->ihevc_chroma_itrans_recon_8x8_fptr                =  &ihevc_chroma_itrans_recon_8x8;
+    ps_func_selector->ihevc_chroma_itrans_recon_16x16_fptr              =  &ihevc_chroma_itrans_recon_16x16;
+    ps_func_selector->ihevc_chroma_itrans_recon_32x32_fptr              =  &ihevc_chroma_itrans_recon_32x32;
+    ps_func_selector->ihevc_recon_4x4_ttype1_fptr                       =  &ihevc_recon_4x4_ttype1;
+    ps_func_selector->ihevc_recon_4x4_fptr                              =  &ihevc_recon_4x4;
+    ps_func_selector->ihevc_recon_8x8_fptr                              =  &ihevc_recon_8x8;
+    ps_func_selector->ihevc_recon_16x16_fptr                            =  &ihevc_recon_16x16;
+    ps_func_selector->ihevc_recon_32x32_fptr                            =  &ihevc_recon_32x32;
+    ps_func_selector->ihevc_chroma_recon_4x4_fptr                       =  &ihevc_chroma_recon_4x4;
+    ps_func_selector->ihevc_chroma_recon_8x8_fptr                       =  &ihevc_chroma_recon_8x8;
+    ps_func_selector->ihevc_chroma_recon_16x16_fptr                     =  &ihevc_chroma_recon_16x16;
+    ps_func_selector->ihevc_chroma_recon_32x32_fptr                     =  &ihevc_chroma_recon_32x32;
+    ps_func_selector->ihevc_memset_16bit_mul_8_fptr                     =  &ihevc_memset_16bit_mul_8;
+    ps_func_selector->ihevc_memset_16bit_fptr                           =  &ihevc_memset_16bit;
+    ps_func_selector->ihevc_pad_left_luma_fptr                          =  &ihevc_pad_left_luma;
+    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma;
+    ps_func_selector->ihevc_pad_right_luma_fptr                         =  &ihevc_pad_right_luma;
+    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma;
+    ps_func_selector->ihevc_weighted_pred_bi_fptr                       =  &ihevc_weighted_pred_bi_sse42;
+    ps_func_selector->ihevc_weighted_pred_bi_default_fptr               =  &ihevc_weighted_pred_bi_default_sse42;
+    ps_func_selector->ihevc_weighted_pred_uni_fptr                      =  &ihevc_weighted_pred_uni_sse42;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_fptr                =  &ihevc_weighted_pred_chroma_bi_sse42;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_default_fptr        =  &ihevc_weighted_pred_chroma_bi_default_ssse3;
+    ps_func_selector->ihevc_weighted_pred_chroma_uni_fptr               =  &ihevc_weighted_pred_chroma_uni_sse42;
+    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma_ssse3;
+    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma_ssse3;
+}

--- a/common/x86/ihevc_function_selector_ssse3.c
+++ b/common/x86/ihevc_function_selector_ssse3.c
@@ -1,0 +1,137 @@
+/******************************************************************************
+*
+* Copyright (C) 2026 Ittiam Systems Pvt Ltd, Bangalore
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
+/**
+*******************************************************************************
+* @file
+*  ihevc_function_selector_ssse3.c
+*
+* @brief
+*  Contains functions to initialize function pointers used in hevc
+*
+* @author
+*  Naveen
+*
+* @par List of Functions:
+* @remarks
+*  None
+*
+*******************************************************************************
+*/
+/*****************************************************************************/
+/* File Includes                                                             */
+/*****************************************************************************/
+#include "ihevc_function_selector.h"
+
+void ihevc_init_function_ptr_ssse3(ihevc_func_selector_t *ps_func_selector)
+{
+    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz_ssse3;
+    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_ssse3;
+    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_ssse3;
+    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_horz_w16out_fptr          =  &ihevc_inter_pred_chroma_horz_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_fptr                 =  &ihevc_inter_pred_chroma_vert_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_fptr          =  &ihevc_inter_pred_chroma_vert_w16inp_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr   =  &ihevc_inter_pred_chroma_vert_w16inp_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_chroma_vert_w16out_fptr          =  &ihevc_inter_pred_chroma_vert_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_horz_fptr                   =  &ihevc_inter_pred_luma_horz_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_fptr                   =  &ihevc_inter_pred_luma_vert_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16out_fptr            =  &ihevc_inter_pred_luma_vert_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_fptr            =  &ihevc_inter_pred_luma_vert_w16inp_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_copy_fptr                   =  &ihevc_inter_pred_luma_copy_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_copy_w16out_fptr            =  &ihevc_inter_pred_luma_copy_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_horz_w16out_fptr            =  &ihevc_inter_pred_luma_horz_w16out_ssse3;
+    ps_func_selector->ihevc_inter_pred_luma_vert_w16inp_w16out_fptr     =  &ihevc_inter_pred_luma_vert_w16inp_w16out_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_substitution_fptr     =  &ihevc_intra_pred_chroma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_substitution_fptr       =  &ihevc_intra_pred_luma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_subst_all_avlble_fptr   =  &ihevc_intra_pred_luma_ref_subst_all_avlble;
+    ps_func_selector->ihevc_intra_pred_ref_filtering_fptr               =  &ihevc_intra_pred_ref_filtering_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_filtering_fptr        =  &ihevc_intra_pred_chroma_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_dc_fptr                   =  &ihevc_intra_pred_chroma_dc_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_horz_fptr                 =  &ihevc_intra_pred_chroma_horz_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode2_fptr                =  &ihevc_intra_pred_chroma_mode2_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_18_34_fptr           =  &ihevc_intra_pred_chroma_mode_18_34_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_27_to_33_fptr        =  &ihevc_intra_pred_chroma_mode_27_to_33_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_3_to_9_fptr          =  &ihevc_intra_pred_chroma_mode_3_to_9_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_planar_fptr               =  &ihevc_intra_pred_chroma_planar_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_ver_fptr                  =  &ihevc_intra_pred_chroma_ver_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_11_to_17_fptr        =  &ihevc_intra_pred_chroma_mode_11_to_17_ssse3;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_19_to_25_fptr        =  &ihevc_intra_pred_chroma_mode_19_to_25_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_11_to_17_fptr          =  &ihevc_intra_pred_luma_mode_11_to_17_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_19_to_25_fptr          =  &ihevc_intra_pred_luma_mode_19_to_25_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_dc_fptr                     =  &ihevc_intra_pred_luma_dc_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_horz_fptr                   =  &ihevc_intra_pred_luma_horz_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode2_fptr                  =  &ihevc_intra_pred_luma_mode2_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_18_34_fptr             =  &ihevc_intra_pred_luma_mode_18_34_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_27_to_33_fptr          =  &ihevc_intra_pred_luma_mode_27_to_33_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_mode_3_to_9_fptr            =  &ihevc_intra_pred_luma_mode_3_to_9_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_planar_fptr                 =  &ihevc_intra_pred_luma_planar_ssse3;
+    ps_func_selector->ihevc_intra_pred_luma_ver_fptr                    =  &ihevc_intra_pred_luma_ver_ssse3;
+    ps_func_selector->ihevc_itrans_4x4_ttype1_fptr                      =  &ihevc_itrans_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_4x4_fptr                             =  &ihevc_itrans_4x4;
+    ps_func_selector->ihevc_itrans_8x8_fptr                             =  &ihevc_itrans_8x8;
+    ps_func_selector->ihevc_itrans_16x16_fptr                           =  &ihevc_itrans_16x16;
+    ps_func_selector->ihevc_itrans_32x32_fptr                           =  &ihevc_itrans_32x32;
+    ps_func_selector->ihevc_itrans_res_4x4_ttype1_fptr                  =  &ihevc_itrans_res_4x4_ttype1;
+    ps_func_selector->ihevc_itrans_res_4x4_fptr                         =  &ihevc_itrans_res_4x4;
+    ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
+    ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
+    ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_ssse3;
+    ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_ssse3;
+    ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_ssse3;
+    ps_func_selector->ihevc_itrans_recon_16x16_fptr                     =  &ihevc_itrans_recon_16x16_ssse3;
+    ps_func_selector->ihevc_itrans_recon_32x32_fptr                     =  &ihevc_itrans_recon_32x32_ssse3;
+    ps_func_selector->ihevc_chroma_itrans_recon_4x4_fptr                =  &ihevc_chroma_itrans_recon_4x4;
+    ps_func_selector->ihevc_chroma_itrans_recon_8x8_fptr                =  &ihevc_chroma_itrans_recon_8x8;
+    ps_func_selector->ihevc_chroma_itrans_recon_16x16_fptr              =  &ihevc_chroma_itrans_recon_16x16;
+    ps_func_selector->ihevc_chroma_itrans_recon_32x32_fptr              =  &ihevc_chroma_itrans_recon_32x32;
+    ps_func_selector->ihevc_recon_4x4_ttype1_fptr                       =  &ihevc_recon_4x4_ttype1;
+    ps_func_selector->ihevc_recon_4x4_fptr                              =  &ihevc_recon_4x4;
+    ps_func_selector->ihevc_recon_8x8_fptr                              =  &ihevc_recon_8x8;
+    ps_func_selector->ihevc_recon_16x16_fptr                            =  &ihevc_recon_16x16;
+    ps_func_selector->ihevc_recon_32x32_fptr                            =  &ihevc_recon_32x32;
+    ps_func_selector->ihevc_chroma_recon_4x4_fptr                       =  &ihevc_chroma_recon_4x4;
+    ps_func_selector->ihevc_chroma_recon_8x8_fptr                       =  &ihevc_chroma_recon_8x8;
+    ps_func_selector->ihevc_chroma_recon_16x16_fptr                     =  &ihevc_chroma_recon_16x16;
+    ps_func_selector->ihevc_chroma_recon_32x32_fptr                     =  &ihevc_chroma_recon_32x32;
+    ps_func_selector->ihevc_memset_16bit_mul_8_fptr                     =  &ihevc_memset_16bit_mul_8;
+    ps_func_selector->ihevc_memset_16bit_fptr                           =  &ihevc_memset_16bit;
+    ps_func_selector->ihevc_pad_left_luma_fptr                          =  &ihevc_pad_left_luma;
+    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma;
+    ps_func_selector->ihevc_pad_right_luma_fptr                         =  &ihevc_pad_right_luma;
+    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma;
+    ps_func_selector->ihevc_weighted_pred_bi_fptr                       =  &ihevc_weighted_pred_bi_ssse3;
+    ps_func_selector->ihevc_weighted_pred_bi_default_fptr               =  &ihevc_weighted_pred_bi_default_ssse3;
+    ps_func_selector->ihevc_weighted_pred_uni_fptr                      =  &ihevc_weighted_pred_uni_ssse3;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_fptr                =  &ihevc_weighted_pred_chroma_bi_ssse3;
+    ps_func_selector->ihevc_weighted_pred_chroma_bi_default_fptr        =  &ihevc_weighted_pred_chroma_bi_default_ssse3;
+    ps_func_selector->ihevc_weighted_pred_chroma_uni_fptr               =  &ihevc_weighted_pred_chroma_uni_ssse3;
+    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma_ssse3;
+    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3_ssse3;
+    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma_ssse3;
+}

--- a/tests/common/TestCommon.cc
+++ b/tests/common/TestCommon.cc
@@ -30,9 +30,9 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_inter_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
+
 #include "TestCommon.h"
 // clang-format on
 

--- a/tests/common/TestCommon.h
+++ b/tests/common/TestCommon.h
@@ -33,9 +33,9 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_inter_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
+
 // clang-format on
 
 #include "TestEnums.h"

--- a/tests/common/func_selector.cc
+++ b/tests/common/func_selector.cc
@@ -29,68 +29,67 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_inter_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 // clang-format on
 
-const func_selector_t ref = []() {
-  func_selector_t ret = {};
+const ihevc_func_selector_t ref = []() {
+  ihevc_func_selector_t ret = {};
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
     defined(_M_IX86)
-  ihevcd_init_function_ptr_generic(&ret);
+  ihevc_init_function_ptr_generic(&ret);
 #elif defined(__aarch64__) || defined(__arm__)
-  ihevcd_init_function_ptr_generic(&ret);
+  ihevc_init_function_ptr_generic(&ret);
 #endif
   return ret;
 }();
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
     defined(_M_IX86)
-const func_selector_t test_ssse3 = []() {
-  func_selector_t ret = {};
-  ihevcd_init_function_ptr_ssse3(&ret);
+const ihevc_func_selector_t test_ssse3 = []() {
+  ihevc_func_selector_t ret = {};
+  ihevc_init_function_ptr_ssse3(&ret);
   return ret;
 }();
 
-const func_selector_t test_sse42 = []() {
-  func_selector_t ret = {};
-  ihevcd_init_function_ptr_sse42(&ret);
+const ihevc_func_selector_t test_sse42 = []() {
+  ihevc_func_selector_t ret = {};
+  ihevc_init_function_ptr_sse42(&ret);
   return ret;
 }();
 
 #ifndef DISABLE_AVX2
-const func_selector_t test_avx2 = []() {
-  func_selector_t ret = {};
-  ihevcd_init_function_ptr_avx2(&ret);
+const ihevc_func_selector_t test_avx2 = []() {
+  ihevc_func_selector_t ret = {};
+  ihevc_init_function_ptr_avx2(&ret);
   return ret;
 }();
 #endif
 #elif defined(__aarch64__)
-const func_selector_t test_arm64 = []() {
-  func_selector_t ret = {};
+const ihevc_func_selector_t test_arm64 = []() {
+  ihevc_func_selector_t ret = {};
 #ifdef DARWIN
-  ihevcd_init_function_ptr_generic(&ret);
+  ihevc_init_function_ptr_generic(&ret);
 #else
-  ihevcd_init_function_ptr_av8(&ret);
+  ihevc_init_function_ptr_av8(&ret);
 #endif
   return ret;
 }();
 #elif defined(__arm__)
-const func_selector_t test_arm32 = []() {
-  func_selector_t ret = {};
+const ihevc_func_selector_t test_arm32 = []() {
+  ihevc_func_selector_t ret = {};
 #ifdef DARWIN
-  ihevcd_init_function_ptr_generic(&ret);
+  ihevc_init_function_ptr_generic(&ret);
 #else
-  ihevcd_init_function_ptr_a9q(&ret);
+  ihevc_init_function_ptr_a9q(&ret);
 #endif
   return ret;
 }();
 #endif
 
-const func_selector_t *get_ref_func_ptr() { return &ref; }
+const ihevc_func_selector_t *get_ref_func_ptr() { return &ref; }
 
-const func_selector_t *get_tst_func_ptr(IV_ARCH_T arch) {
+const ihevc_func_selector_t *get_tst_func_ptr(IV_ARCH_T arch) {
   switch (arch) {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386) ||               \
     defined(_M_IX86)

--- a/tests/common/func_selector.h
+++ b/tests/common/func_selector.h
@@ -29,13 +29,11 @@
 
 // clang-format off
 #include "ihevc_typedefs.h"
-#include "ihevc_inter_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 // clang-format on
 
-const func_selector_t *get_ref_func_ptr();
-const func_selector_t *get_tst_func_ptr(IV_ARCH_T arch);
+const ihevc_func_selector_t *get_ref_func_ptr();
+const ihevc_func_selector_t *get_tst_func_ptr(IV_ARCH_T arch);
 
 #endif /* __FUNC_SELECTOR_H__ */

--- a/tests/common/ihevc_chroma_inter_pred_test.cc
+++ b/tests/common/ihevc_chroma_inter_pred_test.cc
@@ -30,9 +30,8 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_inter_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 #include "func_selector.h"
 #include "TestCommon.h"
 // clang-format on
@@ -95,8 +94,8 @@ class ChromaInterPredTest
   dstType* pv_dst_tst;
   WORD8* pi1_coeffs;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 class ChromaInterPred_8_8_Test : public ChromaInterPredTest<UWORD8, UWORD8> {};
@@ -106,34 +105,34 @@ class ChromaInterPred_16_16_Test : public ChromaInterPredTest<WORD16, WORD16> {
 };
 
 TEST_P(ChromaInterPred_8_8_Test, ChromaCopyTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_copy_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_copy_fptr);
 }
 
 TEST_P(ChromaInterPred_8_8_Test, ChromaHorzTest) {
 #if defined(__arm__) || defined(__aarch64__)
   GTEST_SKIP() << "Skipping ChromaHorzTest on ARM";
 #endif
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_horz_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_horz_fptr);
 }
 
 TEST_P(ChromaInterPred_8_8_Test, ChromaVertTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_vert_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_vert_fptr);
 }
 
 TEST_P(ChromaInterPred_8_16_Test, ChromaCopyTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_copy_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_copy_w16out_fptr);
 }
 
 TEST_P(ChromaInterPred_8_16_Test, ChromaHorzTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_horz_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_horz_w16out_fptr);
 }
 
 TEST_P(ChromaInterPred_8_16_Test, ChromaVertTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_vert_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_vert_w16out_fptr);
 }
 
 TEST_P(ChromaInterPred_16_8_Test, ChromaVertTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_vert_w16inp_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_vert_w16inp_fptr);
 }
 
 TEST_P(ChromaInterPred_16_16_Test, ChromaVertTest) {
@@ -146,7 +145,7 @@ TEST_P(ChromaInterPred_16_16_Test, ChromaVertTest) {
   GTEST_SKIP() << "SSE4.2 and SSSE3 are not matching C implementation for "
                   "ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr";
 #endif
-  RunTest(&func_selector_t::ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_chroma_vert_w16inp_w16out_fptr);
 }
 
 // Chroma block sizes are half of luma block sizes (for 4:2:0)

--- a/tests/common/ihevc_chroma_intra_pred_test.cc
+++ b/tests/common/ihevc_chroma_intra_pred_test.cc
@@ -30,9 +30,8 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_chroma_intra_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 #include "func_selector.h"
 #include "TestCommon.h"
 // clang-format on
@@ -103,31 +102,31 @@ class ChromaIntraPredTest
   UWORD8* pu1_dst_ref;
   UWORD8* pu1_dst_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(ChromaIntraPredTest, Run) {
   if (mode == 0)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_planar_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_planar_fptr);
   else if (mode == 1)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_dc_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_dc_fptr);
   else if (mode == 2)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_mode2_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_mode2_fptr);
   else if (mode >= 3 && mode <= 9)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_mode_3_to_9_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_mode_3_to_9_fptr);
   else if (mode == 10)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_horz_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_horz_fptr);
   else if (mode >= 11 && mode <= 17)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_mode_11_to_17_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_mode_11_to_17_fptr);
   else if (mode == 18 || mode == 34)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_mode_18_34_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_mode_18_34_fptr);
   else if (mode >= 19 && mode <= 25)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_mode_19_to_25_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_mode_19_to_25_fptr);
   else if (mode == 26)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_ver_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_ver_fptr);
   else if (mode >= 27 && mode <= 33)
-    RunTest(&func_selector_t::ihevc_intra_pred_chroma_mode_27_to_33_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_chroma_mode_27_to_33_fptr);
   else
     FAIL() << "Invalid mode: " << mode;
 }

--- a/tests/common/ihevc_chroma_itrans_recon_test.cc
+++ b/tests/common/ihevc_chroma_itrans_recon_test.cc
@@ -115,8 +115,8 @@ class ChromaITransReconTest
 
   int trans_size;
   IV_ARCH_T arch;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 
   WORD32 src_strd;
   WORD32 pred_strd;
@@ -132,13 +132,13 @@ class ChromaITransReconTest
 
 TEST_P(ChromaITransReconTest, Run) {
   if (trans_size == 4) {
-    RunTest(&func_selector_t::ihevc_chroma_itrans_recon_4x4_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_itrans_recon_4x4_fptr);
   } else if (trans_size == 8) {
-    RunTest(&func_selector_t::ihevc_chroma_itrans_recon_8x8_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_itrans_recon_8x8_fptr);
   } else if (trans_size == 16) {
-    RunTest(&func_selector_t::ihevc_chroma_itrans_recon_16x16_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_itrans_recon_16x16_fptr);
   } else if (trans_size == 32) {
-    RunTest(&func_selector_t::ihevc_chroma_itrans_recon_32x32_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_itrans_recon_32x32_fptr);
   }
 }
 

--- a/tests/common/ihevc_chroma_recon_test.cc
+++ b/tests/common/ihevc_chroma_recon_test.cc
@@ -105,8 +105,8 @@ class ChromaReconTest : public ::testing::TestWithParam<ChromaReconTestParam> {
   int trans_size;
   int offset;
   IV_ARCH_T arch;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 
   WORD32 src_strd;
   WORD32 pred_strd;
@@ -120,13 +120,13 @@ class ChromaReconTest : public ::testing::TestWithParam<ChromaReconTestParam> {
 
 TEST_P(ChromaReconTest, Run) {
   if (trans_size == 4) {
-    RunTest(&func_selector_t::ihevc_chroma_recon_4x4_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_recon_4x4_fptr);
   } else if (trans_size == 8) {
-    RunTest(&func_selector_t::ihevc_chroma_recon_8x8_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_recon_8x8_fptr);
   } else if (trans_size == 16) {
-    RunTest(&func_selector_t::ihevc_chroma_recon_16x16_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_recon_16x16_fptr);
   } else if (trans_size == 32) {
-    RunTest(&func_selector_t::ihevc_chroma_recon_32x32_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_chroma_recon_32x32_fptr);
   }
 }
 

--- a/tests/common/ihevc_deblk_test.cc
+++ b/tests/common/ihevc_deblk_test.cc
@@ -102,8 +102,8 @@ class DeblkLumaTest : public ::testing::TestWithParam<DeblkLumaParam> {
   std::vector<UWORD8> src_ref;
   std::vector<UWORD8> src_tst;
 
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 TEST_P(DeblkLumaTest, LumaVert) {
@@ -189,8 +189,8 @@ class DeblkChromaTest : public ::testing::TestWithParam<DeblkChromaParam> {
   std::vector<UWORD8> src_ref;
   std::vector<UWORD8> src_tst;
 
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 TEST_P(DeblkChromaTest, ChromaVert) {

--- a/tests/common/ihevc_itrans_recon_test.cc
+++ b/tests/common/ihevc_itrans_recon_test.cc
@@ -108,8 +108,8 @@ protected:
   int trans_size;
   int ttype;
   IV_ARCH_T arch;
-  const func_selector_t *ref_func_selector;
-  const func_selector_t *tst_func_selector;
+  const ihevc_func_selector_t *ref_func_selector;
+  const ihevc_func_selector_t *tst_func_selector;
 
   WORD32 src_strd;
   WORD32 pred_strd;
@@ -126,16 +126,16 @@ protected:
 TEST_P(ITransReconTest, Run) {
   if (trans_size == 4) {
     if (ttype == 1) {
-      RunTest(&func_selector_t::ihevc_itrans_recon_4x4_ttype1_fptr);
+      RunTest(&ihevc_func_selector_t::ihevc_itrans_recon_4x4_ttype1_fptr);
     } else {
-      RunTest(&func_selector_t::ihevc_itrans_recon_4x4_fptr);
+      RunTest(&ihevc_func_selector_t::ihevc_itrans_recon_4x4_fptr);
     }
   } else if (trans_size == 8) {
-    RunTest(&func_selector_t::ihevc_itrans_recon_8x8_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_itrans_recon_8x8_fptr);
   } else if (trans_size == 16) {
-    RunTest(&func_selector_t::ihevc_itrans_recon_16x16_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_itrans_recon_16x16_fptr);
   } else if (trans_size == 32) {
-    RunTest(&func_selector_t::ihevc_itrans_recon_32x32_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_itrans_recon_32x32_fptr);
   }
 }
 

--- a/tests/common/ihevc_itrans_res_test.cc
+++ b/tests/common/ihevc_itrans_res_test.cc
@@ -29,9 +29,8 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_itrans_res.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 #include "func_selector.h"
 #include "TestCommon.h"
 // clang-format on
@@ -91,23 +90,23 @@ protected:
   std::vector<WORD16> tmp_buf;
   std::vector<WORD16> dst_buf_ref;
   std::vector<WORD16> dst_buf_tst;
-  const func_selector_t *tst;
-  const func_selector_t *ref;
+  const ihevc_func_selector_t *tst;
+  const ihevc_func_selector_t *ref;
 };
 
 TEST_P(ITransResTest, Run) {
   if (trans_size == 4) {
     if (ttype == 1) {
-      RunTest(&func_selector_t::ihevc_itrans_res_4x4_ttype1_fptr);
+      RunTest(&ihevc_func_selector_t::ihevc_itrans_res_4x4_ttype1_fptr);
     } else {
-      RunTest(&func_selector_t::ihevc_itrans_res_4x4_fptr);
+      RunTest(&ihevc_func_selector_t::ihevc_itrans_res_4x4_fptr);
     }
   } else if (trans_size == 8) {
-    RunTest(&func_selector_t::ihevc_itrans_res_8x8_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_itrans_res_8x8_fptr);
   } else if (trans_size == 16) {
-    RunTest(&func_selector_t::ihevc_itrans_res_16x16_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_itrans_res_16x16_fptr);
   } else if (trans_size == 32) {
-    RunTest(&func_selector_t::ihevc_itrans_res_32x32_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_itrans_res_32x32_fptr);
   }
 }
 

--- a/tests/common/ihevc_itrans_test.cc
+++ b/tests/common/ihevc_itrans_test.cc
@@ -81,24 +81,24 @@ class ITransTest : public ::testing::TestWithParam<ITransTestParam> {
     // 1. Reference path from selector (generic C)
     if (trans_size == 4) {
       if (ttype == 1) {
-        (ref->*(&func_selector_t::ihevc_itrans_4x4_ttype1_fptr))(
+        (ref->*(&ihevc_func_selector_t::ihevc_itrans_4x4_ttype1_fptr))(
             pi2_src.data(), pi2_dst_ref.data(), src_strd, dst_strd, shift,
             zero_cols);
       } else {
-        (ref->*(&func_selector_t::ihevc_itrans_4x4_fptr))(
+        (ref->*(&ihevc_func_selector_t::ihevc_itrans_4x4_fptr))(
             pi2_src.data(), pi2_dst_ref.data(), src_strd, dst_strd, shift,
             zero_cols);
       }
     } else if (trans_size == 8) {
-      (ref->*(&func_selector_t::ihevc_itrans_8x8_fptr))(
+      (ref->*(&ihevc_func_selector_t::ihevc_itrans_8x8_fptr))(
           pi2_src.data(), pi2_dst_ref.data(), src_strd, dst_strd, shift,
           zero_cols);
     } else if (trans_size == 16) {
-      (ref->*(&func_selector_t::ihevc_itrans_16x16_fptr))(
+      (ref->*(&ihevc_func_selector_t::ihevc_itrans_16x16_fptr))(
           pi2_src.data(), pi2_dst_ref.data(), src_strd, dst_strd, shift,
           zero_cols);
     } else if (trans_size == 32) {
-      (ref->*(&func_selector_t::ihevc_itrans_32x32_fptr))(
+      (ref->*(&ihevc_func_selector_t::ihevc_itrans_32x32_fptr))(
           pi2_src.data(), pi2_dst_ref.data(), src_strd, dst_strd, shift,
           zero_cols);
     }
@@ -106,24 +106,24 @@ class ITransTest : public ::testing::TestWithParam<ITransTestParam> {
     // 2. Test path from selector (SIMD, which might fall back to C)
     if (trans_size == 4) {
       if (ttype == 1) {
-        (tst->*(&func_selector_t::ihevc_itrans_4x4_ttype1_fptr))(
+        (tst->*(&ihevc_func_selector_t::ihevc_itrans_4x4_ttype1_fptr))(
             pi2_src.data(), pi2_dst_tst.data(), src_strd, dst_strd, shift,
             zero_cols);
       } else {
-        (tst->*(&func_selector_t::ihevc_itrans_4x4_fptr))(
+        (tst->*(&ihevc_func_selector_t::ihevc_itrans_4x4_fptr))(
             pi2_src.data(), pi2_dst_tst.data(), src_strd, dst_strd, shift,
             zero_cols);
       }
     } else if (trans_size == 8) {
-      (tst->*(&func_selector_t::ihevc_itrans_8x8_fptr))(
+      (tst->*(&ihevc_func_selector_t::ihevc_itrans_8x8_fptr))(
           pi2_src.data(), pi2_dst_tst.data(), src_strd, dst_strd, shift,
           zero_cols);
     } else if (trans_size == 16) {
-      (tst->*(&func_selector_t::ihevc_itrans_16x16_fptr))(
+      (tst->*(&ihevc_func_selector_t::ihevc_itrans_16x16_fptr))(
           pi2_src.data(), pi2_dst_tst.data(), src_strd, dst_strd, shift,
           zero_cols);
     } else if (trans_size == 32) {
-      (tst->*(&func_selector_t::ihevc_itrans_32x32_fptr))(
+      (tst->*(&ihevc_func_selector_t::ihevc_itrans_32x32_fptr))(
           pi2_src.data(), pi2_dst_tst.data(), src_strd, dst_strd, shift,
           zero_cols);
     }
@@ -137,8 +137,8 @@ class ITransTest : public ::testing::TestWithParam<ITransTestParam> {
   int shift;
   int num_non_zero_cols;
   IV_ARCH_T arch;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 
   WORD32 src_strd;
   WORD32 dst_strd;

--- a/tests/common/ihevc_luma_inter_pred_test.cc
+++ b/tests/common/ihevc_luma_inter_pred_test.cc
@@ -29,9 +29,8 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_inter_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 #include "func_selector.h"
 #include "TestCommon.h"
 // clang-format on
@@ -93,8 +92,8 @@ protected:
   dstType *pv_dst_tst;
   WORD8 *pi1_coeffs;
   IV_ARCH_T arch;
-  const func_selector_t *tst;
-  const func_selector_t *ref;
+  const ihevc_func_selector_t *tst;
+  const ihevc_func_selector_t *ref;
 };
 
 class LumaInterPred_8_8_Test : public LumaInterPredTest<UWORD8, UWORD8> {};
@@ -103,31 +102,31 @@ class LumaInterPred_16_8_Test : public LumaInterPredTest<WORD16, UWORD8> {};
 class LumaInterPred_16_16_Test : public LumaInterPredTest<WORD16, WORD16> {};
 
 TEST_P(LumaInterPred_8_8_Test, LumaCopyTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_copy_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_copy_fptr);
 }
 
 TEST_P(LumaInterPred_8_8_Test, LumaHorzTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_horz_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_horz_fptr);
 }
 
 TEST_P(LumaInterPred_8_8_Test, LumaVertTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_vert_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_vert_fptr);
 }
 
 TEST_P(LumaInterPred_8_16_Test, LumaCopyTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_copy_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_copy_w16out_fptr);
 }
 
 TEST_P(LumaInterPred_8_16_Test, LumaHorzTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_horz_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_horz_w16out_fptr);
 }
 
 TEST_P(LumaInterPred_8_16_Test, LumaVertTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_vert_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_vert_w16out_fptr);
 }
 
 TEST_P(LumaInterPred_16_8_Test, LumaVertTest) {
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_vert_w16inp_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_vert_w16inp_fptr);
 }
 
 TEST_P(LumaInterPred_16_16_Test, LumaVertTest) {
@@ -137,7 +136,7 @@ TEST_P(LumaInterPred_16_16_Test, LumaVertTest) {
   GTEST_SKIP() << "SSE4.2 and SSSE3 are not matching C implementation for "
                   "ihevc_inter_pred_luma_vert_w16inp_w16out_fptr";
 #endif
-  RunTest(&func_selector_t::ihevc_inter_pred_luma_vert_w16inp_w16out_fptr);
+  RunTest(&ihevc_func_selector_t::ihevc_inter_pred_luma_vert_w16inp_w16out_fptr);
 }
 
 auto kLumaInterPredTestParams =

--- a/tests/common/ihevc_luma_intra_pred_test.cc
+++ b/tests/common/ihevc_luma_intra_pred_test.cc
@@ -29,9 +29,8 @@
 // clang-format off
 #include "ihevc_typedefs.h"
 #include "ihevc_intra_pred.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "iv.h"
-#include "ivd.h"
 #include "func_selector.h"
 #include "TestCommon.h"
 // clang-format on
@@ -105,35 +104,35 @@ protected:
   UWORD8 *pu1_dst_ref;
   UWORD8 *pu1_dst_tst;
   IV_ARCH_T arch;
-  const func_selector_t *tst;
-  const func_selector_t *ref;
+  const ihevc_func_selector_t *tst;
+  const ihevc_func_selector_t *ref;
 };
 
 TEST_P(LumaIntraPredTest, Run) {
   if (mode == 0)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_planar_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_planar_fptr);
   else if (mode == 1)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_dc_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_dc_fptr);
   else if (mode == 2)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_mode2_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_mode2_fptr);
   else if (mode >= 3 && mode <= 9)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_mode_3_to_9_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_mode_3_to_9_fptr);
   else if (mode == 10) {
     GTEST_SKIP() << "SIMD implementation is not matching C implementation for "
                     "ihevc_intra_pred_luma_horz_fptr";
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_horz_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_horz_fptr);
   } else if (mode >= 11 && mode <= 17)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_mode_11_to_17_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_mode_11_to_17_fptr);
   else if (mode == 18 || mode == 34)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_mode_18_34_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_mode_18_34_fptr);
   else if (mode >= 19 && mode <= 25)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_mode_19_to_25_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_mode_19_to_25_fptr);
   else if (mode == 26) {
     GTEST_SKIP() << "SIMD implementation is not matching C implementation for "
                     "ihevc_intra_pred_luma_ver_fptr";
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_ver_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_ver_fptr);
   } else if (mode >= 27 && mode <= 33)
-    RunTest(&func_selector_t::ihevc_intra_pred_luma_mode_27_to_33_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_intra_pred_luma_mode_27_to_33_fptr);
   else
     FAIL() << "Invalid mode: " << mode;
 }

--- a/tests/common/ihevc_mem_fns_test.cc
+++ b/tests/common/ihevc_mem_fns_test.cc
@@ -52,14 +52,14 @@ class Memset16BitTest : public ::testing::TestWithParam<MemsetTestParam> {
   int buf_size;
   std::vector<UWORD16> dst_ref;
   std::vector<UWORD16> dst_tst;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 TEST_P(Memset16BitTest, Run) {
-  (ref->*(&func_selector_t::ihevc_memset_16bit_fptr))(dst_ref.data() + offset,
+  (ref->*(&ihevc_func_selector_t::ihevc_memset_16bit_fptr))(dst_ref.data() + offset,
                                                       value, num_words);
-  (tst->*(&func_selector_t::ihevc_memset_16bit_fptr))(dst_tst.data() + offset,
+  (tst->*(&ihevc_func_selector_t::ihevc_memset_16bit_fptr))(dst_tst.data() + offset,
                                                       value, num_words);
   ASSERT_EQ(dst_ref, dst_tst);
 }
@@ -84,14 +84,14 @@ class Memset16BitMul8Test : public ::testing::TestWithParam<MemsetTestParam> {
   int buf_size;
   std::vector<UWORD16> dst_ref;
   std::vector<UWORD16> dst_tst;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 TEST_P(Memset16BitMul8Test, Run) {
-  (ref->*(&func_selector_t::ihevc_memset_16bit_mul_8_fptr))(
+  (ref->*(&ihevc_func_selector_t::ihevc_memset_16bit_mul_8_fptr))(
       dst_ref.data() + offset, value, num_words);
-  (tst->*(&func_selector_t::ihevc_memset_16bit_mul_8_fptr))(
+  (tst->*(&ihevc_func_selector_t::ihevc_memset_16bit_mul_8_fptr))(
       dst_tst.data() + offset, value, num_words);
   ASSERT_EQ(dst_ref, dst_tst);
 }

--- a/tests/common/ihevc_padding_test.cc
+++ b/tests/common/ihevc_padding_test.cc
@@ -87,8 +87,8 @@ class PaddingLumaTest : public ::testing::TestWithParam<PaddingTestParam> {
   int stride, total_ht, buf_size, src_offset;
   std::vector<UWORD8> buf_ref;
   std::vector<UWORD8> buf_tst;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 // --------------------------- Chroma Base Class -----------------------------
@@ -131,8 +131,8 @@ class PaddingChromaTest : public ::testing::TestWithParam<PaddingTestParam> {
   int stride, total_ht, buf_size, src_offset;
   std::vector<UWORD8> buf_ref;
   std::vector<UWORD8> buf_tst;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 // ---------------------------- Test cases -----------------------------------
@@ -140,9 +140,9 @@ class PaddingChromaTest : public ::testing::TestWithParam<PaddingTestParam> {
 class PaddingLeftLumaTest : public PaddingLumaTest {};
 TEST_P(PaddingLeftLumaTest, Run) {
   InitializeBuffers();
-  (ref->*(&func_selector_t::ihevc_pad_left_luma_fptr))(
+  (ref->*(&ihevc_func_selector_t::ihevc_pad_left_luma_fptr))(
       buf_ref.data() + src_offset, stride, ht, pad_size);
-  (tst->*(&func_selector_t::ihevc_pad_left_luma_fptr))(
+  (tst->*(&ihevc_func_selector_t::ihevc_pad_left_luma_fptr))(
       buf_tst.data() + src_offset, stride, ht, pad_size);
   ASSERT_EQ(buf_ref, buf_tst);
 }
@@ -150,9 +150,9 @@ TEST_P(PaddingLeftLumaTest, Run) {
 class PaddingLeftChromaTest : public PaddingChromaTest {};
 TEST_P(PaddingLeftChromaTest, Run) {
   InitializeBuffers();
-  (ref->*(&func_selector_t::ihevc_pad_left_chroma_fptr))(
+  (ref->*(&ihevc_func_selector_t::ihevc_pad_left_chroma_fptr))(
       buf_ref.data() + src_offset, stride, ht, pad_size);
-  (tst->*(&func_selector_t::ihevc_pad_left_chroma_fptr))(
+  (tst->*(&ihevc_func_selector_t::ihevc_pad_left_chroma_fptr))(
       buf_tst.data() + src_offset, stride, ht, pad_size);
   ASSERT_EQ(buf_ref, buf_tst);
 }
@@ -161,9 +161,9 @@ class PaddingRightLumaTest : public PaddingLumaTest {};
 TEST_P(PaddingRightLumaTest, Run) {
   InitializeBuffers();
   int pad_offset = wd;
-  (ref->*(&func_selector_t::ihevc_pad_right_luma_fptr))(
+  (ref->*(&ihevc_func_selector_t::ihevc_pad_right_luma_fptr))(
       buf_ref.data() + src_offset + pad_offset, stride, ht, pad_size);
-  (tst->*(&func_selector_t::ihevc_pad_right_luma_fptr))(
+  (tst->*(&ihevc_func_selector_t::ihevc_pad_right_luma_fptr))(
       buf_tst.data() + src_offset + pad_offset, stride, ht, pad_size);
   ASSERT_EQ(buf_ref, buf_tst);
 }
@@ -172,9 +172,9 @@ class PaddingRightChromaTest : public PaddingChromaTest {};
 TEST_P(PaddingRightChromaTest, Run) {
   InitializeBuffers();
   int pad_offset = 2 * wd;
-  (ref->*(&func_selector_t::ihevc_pad_right_chroma_fptr))(
+  (ref->*(&ihevc_func_selector_t::ihevc_pad_right_chroma_fptr))(
       buf_ref.data() + src_offset + pad_offset, stride, ht, pad_size);
-  (tst->*(&func_selector_t::ihevc_pad_right_chroma_fptr))(
+  (tst->*(&ihevc_func_selector_t::ihevc_pad_right_chroma_fptr))(
       buf_tst.data() + src_offset + pad_offset, stride, ht, pad_size);
   ASSERT_EQ(buf_ref, buf_tst);
 }

--- a/tests/common/ihevc_recon_test.cc
+++ b/tests/common/ihevc_recon_test.cc
@@ -132,8 +132,8 @@ class ReconTest : public ::testing::TestWithParam<ReconTestParam> {
   int trans_size;
   int ttype;
   IV_ARCH_T arch;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 
   WORD32 src_strd;
   WORD32 pred_strd;
@@ -148,16 +148,16 @@ class ReconTest : public ::testing::TestWithParam<ReconTestParam> {
 TEST_P(ReconTest, Run) {
   if (trans_size == 4) {
     if (ttype == 1) {
-      RunTest(&func_selector_t::ihevc_recon_4x4_ttype1_fptr);
+      RunTest(&ihevc_func_selector_t::ihevc_recon_4x4_ttype1_fptr);
     } else {
-      RunTest(&func_selector_t::ihevc_recon_4x4_fptr);
+      RunTest(&ihevc_func_selector_t::ihevc_recon_4x4_fptr);
     }
   } else if (trans_size == 8) {
-    RunTest(&func_selector_t::ihevc_recon_8x8_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_recon_8x8_fptr);
   } else if (trans_size == 16) {
-    RunTest(&func_selector_t::ihevc_recon_16x16_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_recon_16x16_fptr);
   } else if (trans_size == 32) {
-    RunTest(&func_selector_t::ihevc_recon_32x32_fptr);
+    RunTest(&ihevc_func_selector_t::ihevc_recon_32x32_fptr);
   }
 }
 

--- a/tests/common/ihevc_sao_test.cc
+++ b/tests/common/ihevc_sao_test.cc
@@ -154,8 +154,8 @@ class SaoLumaTest : public ::testing::TestWithParam<SaoTestParam> {
   std::vector<UWORD8> src_bot_left_tst;
   std::vector<UWORD8> avail;
   std::vector<WORD8> sao_offset;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 // --------------------------- Chroma Base Class -----------------------------
@@ -258,8 +258,8 @@ class SaoChromaTest : public ::testing::TestWithParam<SaoTestParam> {
   std::vector<UWORD8> avail;
   std::vector<WORD8> sao_offset_u;
   std::vector<WORD8> sao_offset_v;
-  const func_selector_t* ref;
-  const func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
 };
 
 // ---------------------------- Test cases -----------------------------------

--- a/tests/common/ihevc_weighted_pred_test.cc
+++ b/tests/common/ihevc_weighted_pred_test.cc
@@ -34,7 +34,7 @@
 #include "ihevc_macros.h"
 #include "ihevc_platform_macros.h"
 #include "ihevc_typedefs.h"
-#include "ihevcd_function_selector.h"
+#include "ihevc_function_selector.h"
 #include "TestCommon.h"
 // clang-format on
 
@@ -85,8 +85,8 @@ class WeightedPredUniLumaTest
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(WeightedPredUniLumaTest, Run) {
@@ -146,8 +146,8 @@ class WeightedPredUniChromaTest
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(WeightedPredUniChromaTest, Run) {
@@ -210,8 +210,8 @@ class WeightedPredBiLumaTest
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(WeightedPredBiLumaTest, Run) {
@@ -277,8 +277,8 @@ class WeightedPredBiChromaTest
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(WeightedPredBiChromaTest, Run) {
@@ -349,8 +349,8 @@ class WeightedPredBiDefaultLumaTest
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(WeightedPredBiDefaultLumaTest, Run) {
@@ -407,8 +407,8 @@ class WeightedPredBiDefaultChromaTest
   std::vector<UWORD8> dst_buf_ref;
   std::vector<UWORD8> dst_buf_tst;
   IV_ARCH_T arch;
-  const func_selector_t* tst;
-  const func_selector_t* ref;
+  const ihevc_func_selector_t* tst;
+  const ihevc_func_selector_t* ref;
 };
 
 TEST_P(WeightedPredBiDefaultChromaTest, Run) {


### PR DESCRIPTION
This is needed to ensure that the tests in tests/common do not depend on headers from decoder folder.

Decoder still has its own function selectors and those will be updated in subsequent commits to use these common selectors to avoid code duplication.