### PR TITLE
Remove incorrect prefix from ihevcd_itrans_res_dc

### DIFF
--- a/common/arm/ihevc_function_selector_a9q.c
+++ b/common/arm/ihevc_function_selector_a9q.c
@@ -94,6 +94,7 @@ void ihevc_init_function_ptr_a9q(ihevc_func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_a9q;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_a9q;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_a9q;

--- a/common/arm64/ihevc_function_selector_av8.c
+++ b/common/arm64/ihevc_function_selector_av8.c
@@ -94,6 +94,7 @@ void ihevc_init_function_ptr_av8(ihevc_func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_av8;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_av8;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_av8;

--- a/common/ihevc_function_selector.h
+++ b/common/ihevc_function_selector.h
@@ -114,6 +114,7 @@ typedef struct
     ihevc_itrans_res_8x8_ft *ihevc_itrans_res_8x8_fptr;
     ihevc_itrans_res_16x16_ft *ihevc_itrans_res_16x16_fptr;
     ihevc_itrans_res_32x32_ft *ihevc_itrans_res_32x32_fptr;
+    ihevc_itrans_res_dc_ft *ihevc_itrans_res_dc_fptr;
     ihevc_itrans_recon_4x4_ttype1_ft *ihevc_itrans_recon_4x4_ttype1_fptr;
     ihevc_itrans_recon_4x4_ft *ihevc_itrans_recon_4x4_fptr;
     ihevc_itrans_recon_8x8_ft *ihevc_itrans_recon_8x8_fptr;

--- a/common/ihevc_function_selector_generic.c
+++ b/common/ihevc_function_selector_generic.c
@@ -96,6 +96,7 @@ void ihevc_init_function_ptr_generic(ihevc_func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8;

--- a/common/ihevc_itrans_res.c
+++ b/common/ihevc_itrans_res.c
@@ -29,7 +29,7 @@
  * @par List of Functions:
  *  - ihevc_itrans_res_4x4_ttype1()
  *  - ihevc_itrans_res_4x4()
- *  - ihevcd_itrans_res_dc()
+ *  - ihevc_itrans_res_dc()
  *  - ihevc_itrans_res_8x8()
  *  - ihevc_itrans_res_16x16()
  *  - ihevc_itrans_res_32x32()
@@ -237,7 +237,7 @@ void ihevc_itrans_res_4x4(WORD16 *pi2_src,
 }
 
 
-void ihevcd_itrans_res_dc(WORD16 *pi2_dst,
+void ihevc_itrans_res_dc(WORD16 *pi2_dst,
                           WORD32 dst_strd,
                           WORD32 log2_trans_size,
                           WORD16 i2_coeff_value)

--- a/common/ihevc_itrans_res.h
+++ b/common/ihevc_itrans_res.h
@@ -50,10 +50,10 @@ typedef void ihevc_itrans_res_4x4_ft(WORD16 *pi2_src,
                                      WORD32 zero_cols,
                                      WORD32 zero_rows);
 
-typedef void ihevcd_itrans_res_dc_ft(WORD16 *pi2_dst,
-                                     WORD32 dst_strd,
-                                     WORD32 log2_trans_size,
-                                     WORD16 i2_coeff_value);
+typedef void ihevc_itrans_res_dc_ft(WORD16 *pi2_dst,
+                                    WORD32 dst_strd,
+                                    WORD32 log2_trans_size,
+                                    WORD16 i2_coeff_value);
 
 typedef void ihevc_itrans_res_8x8_ft(WORD16 *pi2_src,
                                      WORD16 *pi2_tmp,
@@ -95,7 +95,7 @@ typedef void ihevc_res_nxn_transform(WORD16 *pi2_src,
 /* C function declarations */
 ihevc_itrans_res_4x4_ttype1_ft ihevc_itrans_res_4x4_ttype1;
 ihevc_itrans_res_4x4_ft ihevc_itrans_res_4x4;
-ihevcd_itrans_res_dc_ft ihevcd_itrans_res_dc;
+ihevc_itrans_res_dc_ft ihevc_itrans_res_dc;
 ihevc_itrans_res_8x8_ft ihevc_itrans_res_8x8;
 ihevc_itrans_res_16x16_ft ihevc_itrans_res_16x16;
 ihevc_itrans_res_32x32_ft ihevc_itrans_res_32x32;

--- a/common/x86/ihevc_function_selector_sse42.c
+++ b/common/x86/ihevc_function_selector_sse42.c
@@ -94,6 +94,7 @@ void ihevc_init_function_ptr_sse42(ihevc_func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_sse42;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_sse42;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_sse42;

--- a/common/x86/ihevc_function_selector_ssse3.c
+++ b/common/x86/ihevc_function_selector_ssse3.c
@@ -94,6 +94,7 @@ void ihevc_init_function_ptr_ssse3(ihevc_func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_ssse3;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_ssse3;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_ssse3;

--- a/decoder/arm/ihevcd_function_selector_a9q.c
+++ b/decoder/arm/ihevcd_function_selector_a9q.c
@@ -113,6 +113,7 @@ void ihevcd_init_function_ptr_a9q(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_a9q;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_a9q;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_a9q;
@@ -158,5 +159,4 @@ void ihevcd_init_function_ptr_a9q(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_fmt_conv_444sp_to_444p_fptr                =  &ihevcd_fmt_conv_444sp_to_444p;
     ps_func_selector->ihevcd_itrans_recon_dc_luma_fptr                  =  &ihevcd_itrans_recon_dc_luma_a9q;
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma_a9q;
-    ps_func_selector->ihevcd_itrans_res_dc_fptr                         =  &ihevcd_itrans_res_dc;
 }

--- a/decoder/arm64/ihevcd_function_selector_av8.c
+++ b/decoder/arm64/ihevcd_function_selector_av8.c
@@ -113,6 +113,7 @@ void ihevcd_init_function_ptr_av8(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_av8;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_av8;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_av8;
@@ -158,5 +159,4 @@ void ihevcd_init_function_ptr_av8(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_fmt_conv_444sp_to_444p_fptr                =  &ihevcd_fmt_conv_444sp_to_444p;
     ps_func_selector->ihevcd_itrans_recon_dc_luma_fptr                  =  &ihevcd_itrans_recon_dc_luma_av8;
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma_av8;
-    ps_func_selector->ihevcd_itrans_res_dc_fptr                         =  &ihevcd_itrans_res_dc;
 }

--- a/decoder/ihevcd_api.c
+++ b/decoder/ihevcd_api.c
@@ -1015,7 +1015,7 @@ void ihevcd_update_function_ptr(codec_t *ps_codec)
     ps_codec->apf_itrans_recon_dc[0] = (pf_itrans_recon_dc)ps_codec->s_func_selector.ihevcd_itrans_recon_dc_luma_fptr;
     ps_codec->apf_itrans_recon_dc[1] = (pf_itrans_recon_dc)ps_codec->s_func_selector.ihevcd_itrans_recon_dc_chroma_fptr;
 
-    ps_codec->apf_itrans_res_dc = (pf_itrans_res_dc)ps_codec->s_func_selector.ihevcd_itrans_res_dc_fptr;
+    ps_codec->apf_itrans_res_dc = (pf_itrans_res_dc)ps_codec->s_func_selector.ihevc_itrans_res_dc_fptr;
 
     /* Init sao function array */
     ps_codec->apf_sao_luma[0] = (pf_sao_luma)ps_codec->s_func_selector.ihevc_sao_edge_offset_class0_fptr;

--- a/decoder/ihevcd_function_selector.h
+++ b/decoder/ihevcd_function_selector.h
@@ -133,6 +133,7 @@ typedef struct
     ihevc_itrans_res_8x8_ft *ihevc_itrans_res_8x8_fptr;
     ihevc_itrans_res_16x16_ft *ihevc_itrans_res_16x16_fptr;
     ihevc_itrans_res_32x32_ft *ihevc_itrans_res_32x32_fptr;
+    ihevc_itrans_res_dc_ft *ihevc_itrans_res_dc_fptr;
     ihevc_itrans_recon_4x4_ttype1_ft *ihevc_itrans_recon_4x4_ttype1_fptr;
     ihevc_itrans_recon_4x4_ft *ihevc_itrans_recon_4x4_fptr;
     ihevc_itrans_recon_8x8_ft *ihevc_itrans_recon_8x8_fptr;
@@ -178,7 +179,6 @@ typedef struct
     ihevcd_fmt_conv_444sp_to_444p_ft *ihevcd_fmt_conv_444sp_to_444p_fptr;
     ihevcd_itrans_recon_dc_luma_ft *ihevcd_itrans_recon_dc_luma_fptr;
     ihevcd_itrans_recon_dc_chroma_ft *ihevcd_itrans_recon_dc_chroma_fptr;
-    ihevcd_itrans_res_dc_ft *ihevcd_itrans_res_dc_fptr;
 }func_selector_t;
 
 void ihevcd_init_arch(void *pv_codec);

--- a/decoder/ihevcd_function_selector_generic.c
+++ b/decoder/ihevcd_function_selector_generic.c
@@ -115,6 +115,7 @@ void ihevcd_init_function_ptr_generic(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8;
@@ -160,5 +161,4 @@ void ihevcd_init_function_ptr_generic(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_fmt_conv_444sp_to_444p_fptr                =  &ihevcd_fmt_conv_444sp_to_444p;
     ps_func_selector->ihevcd_itrans_recon_dc_luma_fptr                  =  &ihevcd_itrans_recon_dc_luma;
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma;
-    ps_func_selector->ihevcd_itrans_res_dc_fptr                         =  &ihevcd_itrans_res_dc;
 }

--- a/decoder/x86/ihevcd_function_selector_sse42.c
+++ b/decoder/x86/ihevcd_function_selector_sse42.c
@@ -113,6 +113,7 @@ void ihevcd_init_function_ptr_sse42(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_sse42;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_sse42;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_sse42;
@@ -158,5 +159,4 @@ void ihevcd_init_function_ptr_sse42(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_fmt_conv_444sp_to_444p_fptr                =  &ihevcd_fmt_conv_444sp_to_444p;
     ps_func_selector->ihevcd_itrans_recon_dc_luma_fptr                  =  &ihevcd_itrans_recon_dc_luma_sse42;
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma_sse42;
-    ps_func_selector->ihevcd_itrans_res_dc_fptr                         =  &ihevcd_itrans_res_dc;
 }

--- a/decoder/x86/ihevcd_function_selector_ssse3.c
+++ b/decoder/x86/ihevcd_function_selector_ssse3.c
@@ -113,6 +113,7 @@ void ihevcd_init_function_ptr_ssse3(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_itrans_res_8x8_fptr                         =  &ihevc_itrans_res_8x8;
     ps_func_selector->ihevc_itrans_res_16x16_fptr                       =  &ihevc_itrans_res_16x16;
     ps_func_selector->ihevc_itrans_res_32x32_fptr                       =  &ihevc_itrans_res_32x32;
+    ps_func_selector->ihevc_itrans_res_dc_fptr                          =  &ihevc_itrans_res_dc;
     ps_func_selector->ihevc_itrans_recon_4x4_ttype1_fptr                =  &ihevc_itrans_recon_4x4_ttype1_ssse3;
     ps_func_selector->ihevc_itrans_recon_4x4_fptr                       =  &ihevc_itrans_recon_4x4_ssse3;
     ps_func_selector->ihevc_itrans_recon_8x8_fptr                       =  &ihevc_itrans_recon_8x8_ssse3;
@@ -158,5 +159,4 @@ void ihevcd_init_function_ptr_ssse3(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_fmt_conv_444sp_to_444p_fptr                =  &ihevcd_fmt_conv_444sp_to_444p;
     ps_func_selector->ihevcd_itrans_recon_dc_luma_fptr                  =  &ihevcd_itrans_recon_dc_luma_ssse3;
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma_ssse3;
-    ps_func_selector->ihevcd_itrans_res_dc_fptr                         =  &ihevcd_itrans_res_dc;
 }


### PR DESCRIPTION
ihevcd_itrans_res_dc is defined in common folder but has a wrong prefix of ihevcd_. This is now fixed to ihevc_.