### PR TITLE
libhevcdec: Enable architecture-specific SIMD optimizations for 422 a…

### DIFF
--- a/decoder/ihevcd_function_selector.h
+++ b/decoder/ihevcd_function_selector.h
@@ -185,6 +185,8 @@ void ihevcd_init_arch(void *pv_codec);
 
 void ihevcd_init_function_ptr(void *pv_codec);
 
+void ihevcd_init_function_ptr_rext_generic(func_selector_t *ps_func_selector);
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/decoder/ihevcd_function_selector_generic.c
+++ b/decoder/ihevcd_function_selector_generic.c
@@ -162,3 +162,43 @@ void ihevcd_init_function_ptr_generic(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_itrans_recon_dc_luma_fptr                  =  &ihevcd_itrans_recon_dc_luma;
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma;
 }
+
+void ihevcd_init_function_ptr_rext_generic(func_selector_t *ps_func_selector)
+{
+    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz;
+    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert;
+    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert;
+    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
+
+    ps_func_selector->ihevc_intra_pred_chroma_ref_substitution_fptr     =  &ihevc_intra_pred_chroma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_substitution_fptr       =  &ihevc_intra_pred_luma_ref_substitution;
+    ps_func_selector->ihevc_intra_pred_luma_ref_subst_all_avlble_fptr   =  &ihevc_intra_pred_luma_ref_subst_all_avlble;
+    ps_func_selector->ihevc_intra_pred_ref_filtering_fptr               =  &ihevc_intra_pred_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_ref_filtering_fptr        =  &ihevc_intra_pred_chroma_ref_filtering;
+    ps_func_selector->ihevc_intra_pred_chroma_dc_fptr                   =  &ihevc_intra_pred_chroma_dc;
+    ps_func_selector->ihevc_intra_pred_chroma_horz_fptr                 =  &ihevc_intra_pred_chroma_horz;
+    ps_func_selector->ihevc_intra_pred_chroma_mode2_fptr                =  &ihevc_intra_pred_chroma_mode2;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_18_34_fptr           =  &ihevc_intra_pred_chroma_mode_18_34;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_27_to_33_fptr        =  &ihevc_intra_pred_chroma_mode_27_to_33;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_3_to_9_fptr          =  &ihevc_intra_pred_chroma_mode_3_to_9;
+    ps_func_selector->ihevc_intra_pred_chroma_planar_fptr               =  &ihevc_intra_pred_chroma_planar;
+    ps_func_selector->ihevc_intra_pred_chroma_ver_fptr                  =  &ihevc_intra_pred_chroma_ver;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_11_to_17_fptr        =  &ihevc_intra_pred_chroma_mode_11_to_17;
+    ps_func_selector->ihevc_intra_pred_chroma_mode_19_to_25_fptr        =  &ihevc_intra_pred_chroma_mode_19_to_25;
+
+    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma;
+    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma;
+
+    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma;
+    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0;
+    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1;
+    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2;
+    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma;
+    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3;
+    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma;
+}

--- a/decoder/ihevcd_parse_headers.c
+++ b/decoder/ihevcd_parse_headers.c
@@ -1622,11 +1622,13 @@ IHEVCD_ERROR_T ihevcd_parse_sps(codec_t *ps_codec)
     ps_sps->i1_chroma_format_idc = value;
 
 #ifdef ENABLE_MAIN_REXT_PROFILE
-    // TODO: re enable simd optimizations once they are updated for 422, 444 internal color formats
+    /* TODO: re enable simd optimizations once they are updated for 422, 444 internal color formats.
+     * Currently, we initialize all pointers as per arch, but override intra pred, SAO, deblocking
+     * and chroma padding to their generic C implementations. */
     if(ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV422 ||
        ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV444)
     {
-        ihevcd_init_function_ptr_generic(&ps_codec->s_func_selector);
+        ihevcd_init_function_ptr_rext_generic(&ps_codec->s_func_selector);
         ihevcd_update_function_ptr(ps_codec);
     }
 #endif


### PR DESCRIPTION
…nd 444

Previously, when 422 or 444 chroma formats were encountered, all function pointers were overridden to generic C implementations due to lack of support in optimized assemblies/intrinsics for certain components.

This change introduces `ihevcd_init_function_ptr_rext` which:
- First initializes all function pointers with architecture-optimized versions.
- Explicitly overrides only the components not yet optimized for 422/444 formats (intra prediction, SAO, deblocking and chroma padding) to point back to their C implementations.

This allows other fully-compatible modules (e.g: inter prediction modes, transform/reconstruction, format conversion) to benefit from SIMD optimizations on 422/444 formats without degrading YUV 420 decoding.

Test: ./hevcdec

Change-Id: I013e44e024258f2f84690fdc0109200129042145