### PR TITLE
libhevcdec: Reapply deblocking assembly changes for YUV444 and YUV422

### DIFF
--- a/common/arm/ihevc_deblk_chroma_horz.s
+++ b/common/arm/ihevc_deblk_chroma_horz.s
@@ -41,6 +41,7 @@
 .equ    tc_offset_div2_offset,  48
 .equ    filter_p_offset,        52
 .equ    filter_q_offset,        56
+.equ    chroma_fmt,             60
 
 .text
 .align 4
@@ -76,6 +77,7 @@ ihevc_deblk_chroma_horz_a9q:
     ldr         r8,[sp,#filter_p_offset]
     vld1.8      {d16},[r6]
     ldr         r9,[sp,#filter_q_offset]
+    ldrsb       r11, [sp, #chroma_fmt]
     adds        r1,r10,r2,asr #1
     vmovl.u8    q1,d2
     ldr         r7,[sp,#qp_offset_v_offset]
@@ -83,16 +85,30 @@ ihevc_deblk_chroma_horz_a9q:
 ulbl1:
     add         r3, r3, pc
     bmi         l1.3312
+    cmp         r11,#1
+    bgt         qp_u_min_51_horz
     cmp         r1,#0x39
     ldrle       r1,[r3,r1,lsl #2]
     subgt       r1,r1,#6
+    b           qp_u_done_horz
+qp_u_min_51_horz:
+    cmp         r1,#0x33
+    movgt       r1,#0x33
+qp_u_done_horz:
 l1.3312:
     adds        r2,r7,r2,asr #1
     vmovl.u8    q2,d4
     bmi         l1.3332
+    cmp         r11,#1
+    bgt         qp_v_min_51_horz
     cmp         r2,#0x39
     ldrle       r2,[r3,r2,lsl #2]
     subgt       r2,r2,#6
+    b           qp_v_done_horz
+qp_v_min_51_horz:
+    cmp         r2,#0x33
+    movgt       r2,#0x33
+qp_v_done_horz:
 l1.3332:
     add         r1,r1,r4,lsl #1
     vsub.i16    q3,q0,q1

--- a/common/arm/ihevc_deblk_chroma_vert.s
+++ b/common/arm/ihevc_deblk_chroma_vert.s
@@ -42,6 +42,7 @@
 .equ    tc_offset_div2_offset,  48
 .equ    filter_p_offset,        52
 .equ    filter_q_offset,        56
+.equ    chroma_fmt,             60
 
 .text
 .align 4
@@ -82,18 +83,33 @@ ulbl1:
     add         r7,r7,pc
     ldr         r12,[sp,#filter_p_offset]
     ldr         r6,[sp,#qp_offset_v_offset]
+    ldrsb       r10,[sp,#chroma_fmt]
     bmi         l1.2944
+    cmp         r10,#1
+    bgt         qp_u_min_51_vert
     cmp         r3,#0x39
     ldrle       r3,[r7,r3,lsl #2]
     subgt       r3,r3,#6
+    b           qp_u_done_vert
+qp_u_min_51_vert:
+    cmp         r3,#0x33
+    movgt       r3,#0x33
+qp_u_done_vert:
 l1.2944:
     vtrn.16     d5,d16
     adds        r2,r6,r2,asr #1
     vtrn.16     d17,d4
     bmi         l1.2964
+    cmp         r10,#1
+    bgt         qp_v_min_51_vert
     cmp         r2,#0x39
     ldrle       r2,[r7,r2,lsl #2]
     subgt       r2,r2,#6
+    b           qp_v_done_vert
+qp_v_min_51_vert:
+    cmp         r2,#0x33
+    movgt       r2,#0x33
+qp_v_done_vert:
 l1.2964:
     vtrn.32     d5,d17
     add         r3,r3,r5,lsl #1

--- a/common/arm64/ihevc_deblk_chroma_horz.s
+++ b/common/arm64/ihevc_deblk_chroma_horz.s
@@ -42,7 +42,8 @@
 //                             WORD32 qp_offset_v,
 //                             WORD32 tc_offset_div2,
 //                             WORD32 filter_flag_p,
-//                             WORD32 filter_flag_q)
+//                             WORD32 filter_flag_q,
+//                             WORD8 chroma_fmt)
 //
 
 .include "ihevc_neon_macros.s"
@@ -62,6 +63,7 @@ ENTRY ihevc_deblk_chroma_horz_av8
     sxtw        x6,w6
     ldr         w9, [sp]
     sxtw        x9,w9
+    ldrsb       x11, [sp, #8]
     push_v_regs
     stp         x19, x20,[sp,#-16]!
     mov         x10, x4
@@ -84,22 +86,38 @@ ENTRY ihevc_deblk_chroma_horz_av8
     adrp        x3, :got:gai4_ihevc_qp_table
     ldr         x3, [x3, #:got_lo12:gai4_ihevc_qp_table]
     bmi         l1.3312
+    cmp         x11,#1
+    bgt         qp_u_min_51_horz
     cmp         x1,#0x39
     bgt         lbl78
     ldr         w1, [x3,x1,lsl #2]
 lbl78:
     sub         x20,x1,#6
     csel        x1, x20, x1,gt
+    b           qp_u_done_horz
+qp_u_min_51_horz:
+    mov         x20,#0x33
+    cmp         x1,x20
+    csel        x1, x20, x1,gt
+qp_u_done_horz:
 l1.3312:
     adds        x2,x7,x2,asr #1
     uxtl        v4.8h, v4.8b
     bmi         l1.3332
+    cmp         x11,#1
+    bgt         qp_v_min_51_horz
     cmp         x2,#0x39
     bgt         lbl85
     ldr         w2, [x3,x2,lsl #2]
 lbl85:
     sub         x20,x2,#6
     csel        x2, x20, x2,gt
+    b           qp_v_done_horz
+qp_v_min_51_horz:
+    mov         x20,#0x33
+    cmp         x2,x20
+    csel        x2, x20, x2,gt
+qp_v_done_horz:
 l1.3332:
     add         x1,x1,x4,lsl #1
     sub         v6.8h,  v0.8h ,  v2.8h

--- a/common/arm64/ihevc_deblk_chroma_vert.s
+++ b/common/arm64/ihevc_deblk_chroma_vert.s
@@ -44,7 +44,8 @@
 //                             WORD32 qp_offset_v,
 //                             WORD32 tc_offset_div2,
 //                             WORD32 filter_flag_p,
-//                             WORD32 filter_flag_q)
+//                             WORD32 filter_flag_q,
+//                             WORD8 chroma_fmt)
 
 .include "ihevc_neon_macros.s"
 .text
@@ -67,6 +68,7 @@ ENTRY ihevc_deblk_chroma_vert_av8
     mov         x12, x7
     mov         x7, x4
     ldr         w4, [sp]
+    ldrsb       x11, [sp, #8]
 
     push_v_regs
     stp         x19, x20,[sp,#-16]!
@@ -89,8 +91,9 @@ ENTRY ihevc_deblk_chroma_vert_av8
     adrp        x7, :got:gai4_ihevc_qp_table
     ldr         x7, [x7, #:got_lo12:gai4_ihevc_qp_table]
 
-
     bmi         l1.2944
+    cmp         x11,#1
+    bgt         qp_u_min_51_vert
     cmp         x3,#0x39
     bgt         lbl78
     ldr         w3, [x7,x3,lsl #2]
@@ -98,6 +101,12 @@ ENTRY ihevc_deblk_chroma_vert_av8
 lbl78:
     sub         x20,x3,#6
     csel        x3, x20, x3,gt
+    b           qp_u_done_vert
+qp_u_min_51_vert:
+    mov         x20,#0x33
+    cmp         x3,x20
+    csel        x3, x20, x3,gt
+qp_u_done_vert:
 l1.2944:
     trn1        v29.4h, v5.4h, v16.4h
     trn2        v16.4h, v5.4h, v16.4h
@@ -107,6 +116,8 @@ l1.2944:
     trn2        v4.4h, v17.4h, v4.4h
     mov         v17.d[0], v29.d[0]
     bmi         l1.2964
+    cmp         x11,#1
+    bgt         qp_v_min_51_vert
     cmp         x2,#0x39
     bgt         lbl86
     ldr         w2, [x7,x2,lsl #2]
@@ -114,6 +125,12 @@ l1.2944:
 lbl86:
     sub         x20,x2,#6
     csel        x2, x20, x2,gt
+    b           qp_v_done_vert
+qp_v_min_51_vert:
+    mov         x20,#0x33
+    cmp         x2,x20
+    csel        x2, x20, x2,gt
+qp_v_done_vert:
 l1.2964:
     trn1        v29.2s, v5.2s, v17.2s
     trn2        v17.2s, v5.2s, v17.2s

--- a/decoder/arm/ihevcd_function_selector_a9q.c
+++ b/decoder/arm/ihevcd_function_selector_a9q.c
@@ -62,6 +62,8 @@ void ihevcd_init_function_ptr_a9q(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_a9q;
     ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_a9q;
     ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_a9q;
+    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
     ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_a9q;
     ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_a9q;
     ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_a9q;

--- a/decoder/arm64/ihevcd_function_selector_av8.c
+++ b/decoder/arm64/ihevcd_function_selector_av8.c
@@ -62,6 +62,8 @@ void ihevcd_init_function_ptr_av8(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_av8;
     ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_av8;
     ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_av8;
+    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
     ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_av8;
     ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_av8;
     ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_av8;

--- a/decoder/x86/ihevcd_function_selector_sse42.c
+++ b/decoder/x86/ihevcd_function_selector_sse42.c
@@ -62,6 +62,8 @@ void ihevcd_init_function_ptr_sse42(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_ssse3;
     ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_ssse3;
     ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_ssse3;
+    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
     ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_sse42;
     ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_sse42;
     ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_ssse3;

--- a/decoder/x86/ihevcd_function_selector_ssse3.c
+++ b/decoder/x86/ihevcd_function_selector_ssse3.c
@@ -62,6 +62,8 @@ void ihevcd_init_function_ptr_ssse3(func_selector_t *ps_func_selector)
     ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert_ssse3;
     ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert_ssse3;
     ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz_ssse3;
+    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
+    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
     ps_func_selector->ihevc_inter_pred_chroma_copy_fptr                 =  &ihevc_inter_pred_chroma_copy_ssse3;
     ps_func_selector->ihevc_inter_pred_chroma_copy_w16out_fptr          =  &ihevc_inter_pred_chroma_copy_w16out_ssse3;
     ps_func_selector->ihevc_inter_pred_chroma_horz_fptr                 =  &ihevc_inter_pred_chroma_horz_ssse3;


### PR DESCRIPTION
Test: ./hevcdec

TODO: Add assemblies and intrinsics for deblocking 422

Change-Id: I40411c04ab00d7e23843eb1d033c4944e3ec66e9