### PR TITLE
libhevcdec: Fix chroma padding in ARM and ARM64 NEON assembly to supp…

### DIFF
--- a/common/arm/ihevc_padding.s
+++ b/common/arm/ihevc_padding.s
@@ -218,8 +218,11 @@ ihevc_pad_left_chroma_a9q:
 
     stmfd       sp!, {r4-r11, lr}           @stack stores the values of the arguments
 
-loop_start_chroma_left:
-    @ pad size is assumed to be pad_left = 80
+    cmp         r3, #160
+    beq         loop_start_chroma_left_160
+
+loop_start_chroma_left_80:
+    @ pad size is assumed to be 80
     sub         r4,r0,r3
 
     ldrh        r8,[r0]
@@ -239,10 +242,10 @@ loop_start_chroma_left:
     add         r5,r4,r1
 
     vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
-    vst1.8      {d0,d1},[r4]!               @ 16 bytes store
-    vst1.8      {d0,d1},[r4]!               @ 16 bytes store
-    vst1.8      {d0,d1},[r4]!               @ 16 bytes store
-    vst1.8      {d0,d1},[r4]                @ 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]                @128/8 = 16 bytes store
 
     add         r6,r5,r1
 
@@ -260,17 +263,87 @@ loop_start_chroma_left:
     vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
     vst1.8      {d4,d5},[r6]                @128/8 = 16 bytes store
 
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]                @128/8 = 16 bytes store
+
     subs        r2,#4
+    bne         loop_start_chroma_left_80
+
+    ldmfd       sp!,{r4-r11,pc}             @reload the registers from sp
+
+loop_start_chroma_left_160:
+    @ pad size is assumed to be 160
+    sub         r4,r0,r3
+
+    ldrh        r8,[r0]
+    add         r0,r1
+    ldrh        r9,[r0]
+    add         r0,r1
+    ldrh        r10,[r0]
+    add         r0,r1
+    ldrh        r11,[r0]
+    add         r0,r1
+
+    vdup.u16    q0,r8
+    vdup.u16    q1,r9
+    vdup.u16    q2,r10
+    vdup.u16    q3,r11
+
+    add         r5,r4,r1
+
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]                @128/8 = 16 bytes store
+
+    add         r6,r5,r1
+
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]                @128/8 = 16 bytes store
+
+    add         r7,r6,r1
+
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]                @128/8 = 16 bytes store
 
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]                @128/8 = 16 bytes store
 
-    @ total of 4rows*(16*5) = 4 * 80 = 4 * pad_left store
-
-    bne         loop_start_chroma_left
+    subs        r2,#4
+    bne         loop_start_chroma_left_160
 
     ldmfd       sp!,{r4-r11,pc}             @reload the registers from sp
 
@@ -466,8 +539,11 @@ ihevc_pad_right_chroma_a9q:
 
     stmfd       sp!, {r4-r11, lr}           @stack stores the values of the arguments
 
-loop_start_chroma_right:
-    @ pad size is assumed to be pad_left = 80
+    cmp         r3, #160
+    beq         loop_start_chroma_right_160
+
+loop_start_chroma_right_80:
+    @ pad size is assumed to be 80
     mov         r4,r0
 
     ldrh        r8,[r0, #-2]
@@ -487,10 +563,10 @@ loop_start_chroma_right:
     add         r5,r4,r1
 
     vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
-    vst1.8      {d0,d1},[r4]!               @ 16 bytes store
-    vst1.8      {d0,d1},[r4]!               @ 16 bytes store
-    vst1.8      {d0,d1},[r4]!               @ 16 bytes store
-    vst1.8      {d0,d1},[r4]                @ 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]                @128/8 = 16 bytes store
 
     add         r6,r5,r1
 
@@ -508,17 +584,87 @@ loop_start_chroma_right:
     vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
     vst1.8      {d4,d5},[r6]                @128/8 = 16 bytes store
 
-    subs        r2,#4
-
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
     vst1.8      {d6,d7},[r7]                @128/8 = 16 bytes store
 
-    @ total of 4rows*(16*5) = 4 * 80 = 4 * pad_left store
+    subs        r2,#4
+    bne         loop_start_chroma_right_80
 
-    bne         loop_start_chroma_right
+    ldmfd       sp!,{r4-r11,pc}             @reload the registers from sp
+
+loop_start_chroma_right_160:
+    @ pad size is assumed to be 160
+    mov         r4,r0
+
+    ldrh        r8,[r0, #-2]
+    add         r0,r1
+    ldrh        r9,[r0, #-2]
+    add         r0,r1
+    ldrh        r10,[r0, #-2]
+    add         r0,r1
+    ldrh        r11,[r0, #-2]
+    add         r0,r1
+
+    vdup.u16    q0,r8
+    vdup.u16    q1,r9
+    vdup.u16    q2,r10
+    vdup.u16    q3,r11
+
+    add         r5,r4,r1
+
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]!               @128/8 = 16 bytes store
+    vst1.8      {d0,d1},[r4]                @128/8 = 16 bytes store
+
+    add         r6,r5,r1
+
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]!               @128/8 = 16 bytes store
+    vst1.8      {d2,d3},[r5]                @128/8 = 16 bytes store
+
+    add         r7,r6,r1
+
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]!               @128/8 = 16 bytes store
+    vst1.8      {d4,d5},[r6]                @128/8 = 16 bytes store
+
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]!               @128/8 = 16 bytes store
+    vst1.8      {d6,d7},[r7]                @128/8 = 16 bytes store
+
+    subs        r2,#4
+    bne         loop_start_chroma_right_160
 
     ldmfd       sp!,{r4-r11,pc}             @reload the registers from sp
 

--- a/common/arm64/ihevc_padding.s
+++ b/common/arm64/ihevc_padding.s
@@ -212,9 +212,11 @@ loop_start_luma_left:
 
 ENTRY ihevc_pad_left_chroma_av8
 
+    cmp         x3, #160
+    beq         loop_start_chroma_left_160
 
-loop_start_chroma_left:
-    // pad size is assumed to be pad_left = 80
+loop_start_chroma_left_80:
+    // pad size is assumed to be 80
     sub         x4,x0,x3
 
     ldrh        w8,[x0]
@@ -255,17 +257,88 @@ loop_start_chroma_left:
     st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
     st1         {v4.16b},[x6]               //128/8 = 16 bytes store
 
-    subs        x2, x2,#4
-
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7]               //128/8 = 16 bytes store
 
-    // total of 4rows*(16*5) = 4 * 80 = 4 * pad_left store
+    subs        x2, x2,#4
+    bne         loop_start_chroma_left_80
 
-    bne         loop_start_chroma_left
+    EXIT_FUNC
+    ret
+
+loop_start_chroma_left_160:
+    // pad size is assumed to be 160
+    sub         x4,x0,x3
+
+    ldrh        w8,[x0]
+    add         x0,x0,x1
+    ldrh        w9,[x0]
+    add         x0,x0,x1
+    ldrh        w10,[x0]
+    add         x0,x0,x1
+    ldrh        w11,[x0]
+    add         x0,x0,x1
+
+    dup         v0.8h,w8
+    dup         v2.8h,w9
+    dup         v4.8h,w10
+    dup         v6.8h,w11
+
+    add         x5,x4,x1
+
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4]               //128/8 = 16 bytes store
+
+    add         x6,x5,x1
+
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5]               //128/8 = 16 bytes store
+
+    add         x7,x6,x1
+
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6]               //128/8 = 16 bytes store
+
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7]               //128/8 = 16 bytes store
+
+    subs        x2, x2,#4
+    bne         loop_start_chroma_left_160
 
     EXIT_FUNC
     ret
@@ -460,9 +533,11 @@ loop_start_luma_right:
 
 ENTRY ihevc_pad_right_chroma_av8
 
+    cmp         x3, #160
+    beq         loop_start_chroma_right_160
 
-loop_start_chroma_right:
-    // pad size is assumed to be pad_left = 80
+loop_start_chroma_right_80:
+    // pad size is assumed to be 80
     mov         x4,x0
 
     ldrh        w8,[x0, #-2]
@@ -482,10 +557,10 @@ loop_start_chroma_right:
     add         x5,x4,x1
 
     st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
-    st1         {v0.16b},[x4],#16           // 16 bytes store
-    st1         {v0.16b},[x4],#16           // 16 bytes store
-    st1         {v0.16b},[x4],#16           // 16 bytes store
-    st1         {v0.16b},[x4]               // 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4]               //128/8 = 16 bytes store
 
     add         x6,x5,x1
 
@@ -503,17 +578,88 @@ loop_start_chroma_right:
     st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
     st1         {v4.16b},[x6]               //128/8 = 16 bytes store
 
-    subs        x2, x2,#4
-
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
     st1         {v6.16b},[x7]               //128/8 = 16 bytes store
 
-    // total of 4rows*(16*5) = 4 * 80 = 4 * pad_left store
+    subs        x2, x2,#4
+    bne         loop_start_chroma_right_80
 
-    bne         loop_start_chroma_right
+    EXIT_FUNC
+    ret
+
+loop_start_chroma_right_160:
+    // pad size is assumed to be 160
+    mov         x4,x0
+
+    ldrh        w8,[x0, #-2]
+    add         x0,x0,x1
+    ldrh        w9,[x0, #-2]
+    add         x0,x0,x1
+    ldrh        w10,[x0, #-2]
+    add         x0,x0,x1
+    ldrh        w11,[x0, #-2]
+    add         x0,x0,x1
+
+    dup         v0.8h,w8
+    dup         v2.8h,w9
+    dup         v4.8h,w10
+    dup         v6.8h,w11
+
+    add         x5,x4,x1
+
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4],#16           //128/8 = 16 bytes store
+    st1         {v0.16b},[x4]               //128/8 = 16 bytes store
+
+    add         x6,x5,x1
+
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5],#16           //128/8 = 16 bytes store
+    st1         {v2.16b},[x5]               //128/8 = 16 bytes store
+
+    add         x7,x6,x1
+
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6],#16           //128/8 = 16 bytes store
+    st1         {v4.16b},[x6]               //128/8 = 16 bytes store
+
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7],#16           //128/8 = 16 bytes store
+    st1         {v6.16b},[x7]               //128/8 = 16 bytes store
+
+    subs        x2, x2,#4
+    bne         loop_start_chroma_right_160
 
     EXIT_FUNC
     ret


### PR DESCRIPTION
…ort 160-byte width

For the 444 chroma format, the chroma pad width is 160 bytes. However, the ARM and ARM64 NEON chroma padding assembly functions previously assumed a hardcoded pad size of 80 bytes (writing exactly 5 stores of 16 bytes), leaving the rest of the padding region uninitialized.

Test: ./hevcdec

Change-Id: I013e44e024258f2f84690fdc0109200119042135