### PR TITLE
hevcdec: Remove rext generic function pointer override for 422/444

### DIFF
--- a/decoder/ihevcd_function_selector.h
+++ b/decoder/ihevcd_function_selector.h
@@ -185,8 +185,6 @@ void ihevcd_init_arch(void *pv_codec);
 
 void ihevcd_init_function_ptr(void *pv_codec);
 
-void ihevcd_init_function_ptr_rext_generic(func_selector_t *ps_func_selector);
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/decoder/ihevcd_function_selector_generic.c
+++ b/decoder/ihevcd_function_selector_generic.c
@@ -163,26 +163,3 @@ void ihevcd_init_function_ptr_generic(func_selector_t *ps_func_selector)
     ps_func_selector->ihevcd_itrans_recon_dc_chroma_fptr                =  &ihevcd_itrans_recon_dc_chroma;
 }
 
-void ihevcd_init_function_ptr_rext_generic(func_selector_t *ps_func_selector)
-{
-    ps_func_selector->ihevc_deblk_chroma_horz_fptr                      =  &ihevc_deblk_chroma_horz;
-    ps_func_selector->ihevc_deblk_chroma_vert_fptr                      =  &ihevc_deblk_chroma_vert;
-    ps_func_selector->ihevc_deblk_luma_vert_fptr                        =  &ihevc_deblk_luma_vert;
-    ps_func_selector->ihevc_deblk_luma_horz_fptr                        =  &ihevc_deblk_luma_horz;
-    ps_func_selector->ihevc_deblk_422chroma_horz_fptr                   =  &ihevc_deblk_422chroma_horz;
-    ps_func_selector->ihevc_deblk_422chroma_vert_fptr                   =  &ihevc_deblk_422chroma_vert;
-
-    ps_func_selector->ihevc_pad_left_chroma_fptr                        =  &ihevc_pad_left_chroma;
-    ps_func_selector->ihevc_pad_right_chroma_fptr                       =  &ihevc_pad_right_chroma;
-
-    ps_func_selector->ihevc_sao_band_offset_luma_fptr                   =  &ihevc_sao_band_offset_luma;
-    ps_func_selector->ihevc_sao_band_offset_chroma_fptr                 =  &ihevc_sao_band_offset_chroma;
-    ps_func_selector->ihevc_sao_edge_offset_class0_fptr                 =  &ihevc_sao_edge_offset_class0;
-    ps_func_selector->ihevc_sao_edge_offset_class0_chroma_fptr          =  &ihevc_sao_edge_offset_class0_chroma;
-    ps_func_selector->ihevc_sao_edge_offset_class1_fptr                 =  &ihevc_sao_edge_offset_class1;
-    ps_func_selector->ihevc_sao_edge_offset_class1_chroma_fptr          =  &ihevc_sao_edge_offset_class1_chroma;
-    ps_func_selector->ihevc_sao_edge_offset_class2_fptr                 =  &ihevc_sao_edge_offset_class2;
-    ps_func_selector->ihevc_sao_edge_offset_class2_chroma_fptr          =  &ihevc_sao_edge_offset_class2_chroma;
-    ps_func_selector->ihevc_sao_edge_offset_class3_fptr                 =  &ihevc_sao_edge_offset_class3;
-    ps_func_selector->ihevc_sao_edge_offset_class3_chroma_fptr          =  &ihevc_sao_edge_offset_class3_chroma;
-}

--- a/decoder/ihevcd_parse_headers.c
+++ b/decoder/ihevcd_parse_headers.c
@@ -1621,18 +1621,6 @@ IHEVCD_ERROR_T ihevcd_parse_sps(codec_t *ps_codec)
     }
     ps_sps->i1_chroma_format_idc = value;
 
-#ifdef ENABLE_MAIN_REXT_PROFILE
-    /* TODO: re enable simd optimizations once they are updated for 422, 444 internal color formats.
-     * Currently, we initialize all pointers as per arch, but override intra pred, SAO, deblocking
-     * and chroma padding to their generic C implementations. */
-    if(ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV422 ||
-       ps_sps->i1_chroma_format_idc == CHROMA_FMT_IDC_YUV444)
-    {
-        ihevcd_init_function_ptr_rext_generic(&ps_codec->s_func_selector);
-        ihevcd_update_function_ptr(ps_codec);
-    }
-#endif
-
     if(CHROMA_FMT_IDC_YUV444 == ps_sps->i1_chroma_format_idc)
     {
         BITS_PARSE("separate_colour_plane_flag", value, ps_bitstrm, 1);


### PR DESCRIPTION
With SIMD optimizations updated and enabled for 422 and 444 chroma formats, the fallback override in ihevcd_init_function_ptr_rext_generic is no longer necessary.

Test: ./build