### PR TITLE
libhevcdec: Fix chroma SAO neighbor handling for CTB size 16

### DIFF
--- a/decoder/ihevcd_sao.c
+++ b/decoder/ihevcd_sao.c
@@ -2180,10 +2180,15 @@ void ihevcd_sao_shift_ctb(sao_ctxt_t *ps_sao_ctxt)
                         au1_src_bot_left[1] = pu1_sao_src_top_left_chroma_bot_left[1];
                         //au1_src_bot_left[0] = pu1_src_chroma[sao_ht_chroma * src_strd - 2];
                         //au1_src_bot_left[1] = pu1_src_chroma[sao_ht_chroma * src_strd - 1];
-                        if((ctb_size == (8 * h_samp_factor)) && (ps_sao_ctxt->i4_ctb_x != ps_sps->i2_pic_wd_in_ctb - 1))
+                        if((ctb_size == (8 * h_samp_factor)) && (ps_sao_ctxt->i4_ctb_y != 0))
                         {
                             au1_src_top_right[0] = pu1_src_chroma[sao_wd_chroma - chroma_strd];
                             au1_src_top_right[1] = pu1_src_chroma[sao_wd_chroma - chroma_strd + 1];
+                        }
+                        if (ctb_size == (8 * h_samp_factor))
+                        {
+                            au1_src_bot_left[0] = pu1_src_chroma[-2 + sao_ht_chroma * chroma_strd];
+                            au1_src_bot_left[1] = pu1_src_chroma[-1 + sao_ht_chroma * chroma_strd];
                         }
 
 


### PR DESCRIPTION
- For CTB size 16 in 4:2:2, sub-block width is 0, causing the Top and Current SAO blocks to be skipped.
- Fix Top-Right neighbor in Left block to read from picture buffer when ctb_size == 16 and ctb_y != 0, while keeping line buffer for larger CTBs (32, 64).
- Fix Bottom-Left neighbor in Left block to read from picture buffer when ctb_size == 16 to avoid uninitialized backup buffer access.
- Generalize Top-Left block condition to (8 * v_samp_factor).

Test: ./hevcdec

Change-Id: I013e44e024258f2f84690fdc0109210129042245