### PR TITLE
libhevcdec: Fix luma stride in PCM sample copying for HBD

### DIFF
--- a/decoder/ihevcd_iquant_itrans_recon_ctb.c
+++ b/decoder/ihevcd_iquant_itrans_recon_ctb.c
@@ -1151,7 +1151,7 @@ WORD32 ihevcd_iquant_itrans_recon_ctb(process_ctxt_t *ps_proc)
             {
                 for(i = 0; i < cb_size; i++)
                 {
-                    memcpy(&pu1_y_dst[i * pic_strd], pu1_buf, (cb_size * i4_pixel_size_y));
+                    memcpy(&pu1_y_dst[i * pic_strd * i4_pixel_size_y], pu1_buf, (cb_size * i4_pixel_size_y));
                     pu1_buf += cb_size * i4_pixel_size_y;
                 }
 


### PR DESCRIPTION
For High Bit Depth streams, pixel samples occupy 2 bytes (i4_pixel_size_y = 2). In ihevcd_iquant_itrans_recon_ctb, the luma row offset in the destination buffer for IPCM blocks was computed using `i * pic_strd` rather than `i * pic_strd * i4_pixel_size_y`. This caused luma rows in IPCM blocks to overwrite previous rows and corrupt reconstructed pixels.

Updated the row offset indexing to multiply by i4_pixel_size_y.

Test: ./hevcdec