### PR TITLE
Fix OOB read in the bitstream word refill

### DIFF
--- a/decoder/ihevcd_parse_headers.c
+++ b/decoder/ihevcd_parse_headers.c
@@ -3497,7 +3497,10 @@ IHEVCD_ERROR_T ihevcd_parse_sei(codec_t *ps_codec, nal_header_t *ps_nal)
 
         u4_payload_size += u4_last_payload_size_byte;
         u4_bits_left = ihevcd_bits_num_bits_remaining(ps_bitstrm);
-        u4_payload_size = MIN(u4_payload_size, u4_bits_left / 8);
+        if(u4_payload_size > (u4_bits_left / 8))
+        {
+            return (IHEVCD_ERROR_T)IHEVCD_INVALID_PARAMETER;
+        }
         ihevcd_parse_sei_payload(ps_codec, u4_payload_type, u4_payload_size,
                                  ps_nal->i1_nal_unit_type);
 


### PR DESCRIPTION
The patch fixes the OOB read by rejecting the malformed payload length instead of truncating it:

1. Reject the payload when its declared size exceeds the bytes remaining in the NAL, rather than shrinking it with `MIN()`.
2. Return `IHEVCD_INVALID_PARAMETER`, since a declared length that overruns the NAL leaves no trustworthy point to resume parsing from.