### PR TITLE
Fix out-of-bounds read when an SEI payload exceeds the NAL

### DIFF
--- a/decoder/ihevcd_parse_headers.c
+++ b/decoder/ihevcd_parse_headers.c
@@ -3549,7 +3549,10 @@ IHEVCD_ERROR_T ihevcd_parse_sei(codec_t *ps_codec, nal_header_t *ps_nal)
 
         u4_payload_size += u4_last_payload_size_byte;
         u4_bits_left = ihevcd_bits_num_bits_remaining(ps_bitstrm);
-        u4_payload_size = MIN(u4_payload_size, u4_bits_left / 8);
+        if(u4_payload_size > (u4_bits_left / 8))
+        {
+            return (IHEVCD_ERROR_T)IHEVCD_INVALID_PARAMETER;
+        }
         ihevcd_parse_sei_payload(ps_codec, u4_payload_type, u4_payload_size,
                                  ps_nal->i1_nal_unit_type);
 


### PR DESCRIPTION
ihevcd_parse_sei() truncated the declared SEI payload size to the bytes remaining with MIN() instead of rejecting it. The payload parsers do not consult that size, so ihevcd_parse_mastering_disp_params_sei() read its full 24-byte structure out of a one-byte payload and ran past the end of the bitstream buffer.

(cherry picked from commit b21f809576caccbb756c1056f7b416a62bef5f17)