### PR TITLE
libhevc: Remove redundant in-function #include <assert.h>

### DIFF
--- a/common/x86/ihevc_weighted_pred_ssse3_intr.c
+++ b/common/x86/ihevc_weighted_pred_ssse3_intr.c
@@ -754,7 +754,6 @@ void ihevc_weighted_pred_bi_ssse3(WORD16 *pi2_src1,
     __m128i const_temp_4x32b, lvl_shift1_4x32b, lvl_shift2_4x32b, wgt0_8x16b, wgt1_8x16b;
     __m128i res_temp1_4x32b, res_temp2_4x32b, res_temp3_4x32b, res_temp4_4x32b;
 
-#include <assert.h>
     ASSERT(wd % 4 == 0); /* checking assumption*/
     ASSERT(ht % 4 == 0); /* checking assumption*/
 


### PR DESCRIPTION
Including <assert.h> inside the body of ihevc_weighted_pred_bi_ssse3 caused Clang's coverage mapping generator to add assert.h to the function's VirtualFileMapping. Because system headers are filtered out when emitting coverage regions, no region sub-arrays were generated for assert.h, resulting in llvm-cov failing with 'truncated coverage data' when reading the coverage mapping.

Since <assert.h> is already included at file scope, remove the redundant in-function include.

Bug: 539970151
Test: Revert ag/41985629 and then follow the steps below Test: cd frameworks/av/apex && CLANG_COVERAGE=true NATIVE_COVERAGE_PATHS=* mm Test: llvm-cov report -empty-profile out_x64/target/product/vsoc_x86_64_only/symbols/apex/com.android.media.swcodec/lib64/libcodec2_soft_hevcdec.so TAG=agy
CONV=f1fd20b6-de70-47c5-8011-aca1dcbeb9e9

Change-Id: I98bafd5754b7059d5869eb1eb0ea0922ec95cc5e (cherry picked from commit 15aee9ebc525822f4c4eb4b9dc8878a228d48202)