### PR TITLE
[common] Clean up and standardize new HBD source files

### DIFF
--- a/common/ihevc_chroma_recon.h
+++ b/common/ihevc_chroma_recon.h
@@ -130,10 +130,10 @@ void ihevc_hbd_chroma_recon_nxn_ccp(WORD16 *pi2_luma_res,
                                     UWORD16 *pu2_dst,
                                     WORD32 alpha,
                                     WORD32 trans_size,
-                                    WORD32 luma_res_stride,
-                                    WORD32 chroma_res_stride,
-                                    WORD32 pred_stride,
-                                    WORD32 dst_stride,
+                                    WORD32 luma_res_strd,
+                                    WORD32 chroma_res_strd,
+                                    WORD32 pred_strd,
+                                    WORD32 dst_strd,
                                     UWORD8 bit_depth);
 
-#endif /*_IHEVC_CHROMA_RECON_H_*/
+#endif /* _IHEVC_CHROMA_RECON_H_ */

--- a/common/ihevc_hbd_chroma_intra_pred_filters.c
+++ b/common/ihevc_hbd_chroma_intra_pred_filters.c
@@ -159,7 +159,7 @@ void ihevc_hbd_intra_pred_chroma_ref_filtering(UWORD16 *pu2_src,
     }
     else
     {
-        /* Extremities Untouched*/
+        /* Extremities Untouched */
         au2_flt[0] = pu2_src[0];
         au2_flt[1] = pu2_src[1];
         au2_flt[four_nt * 2] = pu2_src[four_nt * 2];
@@ -238,11 +238,10 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
     WORD32 bot_left, left, top, tp_right, tp_left;
     WORD32 idx, nbr_id_from_bl, frwd_nbr_flag;
     WORD32 a_nbr_flag[5];
-    /* Neighbor Flag Structure*/
-    /* WORD32 nbr_flags MSB-->LSB   TOP LEFT | TOP-RIGHT |  TOP   | LEFT    | BOTTOM LEFT*/
+    /* Neighbor Flag Structure */
+    /* WORD32 nbr_flags MSB-->LSB   TOP LEFT | TOP-RIGHT |  TOP   | LEFT    | BOTTOM LEFT */
     /*                              (1 bit)     (4 bits)  (4 bits) (4 bits)  (4 bits)  */
     /* If no neighbor flags are present, fill the neighbor samples with DC value */
-    /*dc_val = 1 << (BIT_DEPTH - 1);*/
     dc_val = 1 << (bit_depth - 1);
     if(nbr_flags == 0)
     {
@@ -321,14 +320,14 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
             a_nbr_flag[3] = top;
             a_nbr_flag[4] = tp_right;
 
-            /* If bottom -left is not available, reverse substitution process*/
+            /* If bottom -left is not available, reverse substitution process */
             if(bot_left == 0)
             {
-                /* Check for the 1st available sample from bottom-left*/
+                /* Check for the 1st available sample from bottom-left */
                 while(!a_nbr_flag[next])
                     next++;
 
-                /* If Left, top-left are available*/
+                /* If Left, top-left are available */
                 if(next <= 2)
                 {
                     idx = (nt * next);
@@ -342,7 +341,7 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
                 }
                 else /* If top, top-right are available */
                 {
-                    /* Idx is changed to copy 1 pixel value for top-left ,if top-left is not available*/
+                    /* Idx is changed to copy 1 pixel value for top-left ,if top-left is not available */
                     idx = (nt * (next - 1)) + 1;
                     pu2_ref_u = pu2_dst[2 * idx];
                     pu2_ref_v = pu2_dst[(2 * idx) + 1];
@@ -393,7 +392,7 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
                             + ((nbr_flags & 0x3000) >> 6)
                             + ((nbr_flags & 0x10000) >> 8);
 
-            /* compute trailing zeors based on nbr_flag for substitution process of below left see section .*/
+            /* compute trailing zeors based on nbr_flag for substitution process of below left see section . */
             /* as each bit in nbr flags corresponds to 8 pels for bot_left, left, top and topright but 1 pel for topleft */
             {
                 nbr_id_from_bl = look_up_trailing_zeros(nbr_flags_temp & 0XF) * (4 * sub_sample); /* for bottom left and left */
@@ -411,7 +410,7 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
 
                     }
                 }
-                /* Reverse Substitution Process*/
+                /* Reverse Substitution Process */
                 if(nbr_id_from_bl)
                 {
                     /* Replicate the bottom-left and subsequent unavailable pixels with the 1st available pixel above */
@@ -430,9 +429,9 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
             {
                 /* To Obtain the next unavailable idx flag after reverse neighbor substitution  */
                 /* Divide by 8 to obtain the original index */
-                frwd_nbr_flag = (nbr_id_from_bl >> (chroma_format_idc == CHROMA_FMT_IDC_YUV444 ? 3 : 2));/*+ (nbr_id_from_bl & 0x1);*/
+                frwd_nbr_flag = (nbr_id_from_bl >> (chroma_format_idc == CHROMA_FMT_IDC_YUV444 ? 3 : 2));
 
-                /* The Top-left flag is at the last bit location of nbr_flags*/
+                /* The Top-left flag is at the last bit location of nbr_flags */
                 if(nbr_id_from_bl == (T8C_4NT * sub_sample / 2))
                 {
                     get_bits = GET_BIT(nbr_flags_temp, 8);
@@ -465,7 +464,7 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
         else if(nt == 16 || (nt == 32 && chroma_format_idc == CHROMA_FMT_IDC_YUV444))
         {
             WORD32 sub_sample = chroma_format_idc == CHROMA_FMT_IDC_YUV444 ? 2 : 1;
-            /* compute trailing ones based on mbr_flag for substitution process of below left see section .*/
+            /* compute trailing ones based on mbr_flag for substitution process of below left see section . */
             /* as each bit in nbr flags corresponds to 4 pels for bot_left, left, top and topright but 1 pel for topleft */
             {
                 nbr_id_from_bl = look_up_trailing_zeros((nbr_flags & 0XFF)) * 4 * sub_sample; /* for bottom left and left */
@@ -481,7 +480,7 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
                         nbr_id_from_bl += look_up_trailing_zeros((nbr_flags >> 8) & 0xFF) * 4 * sub_sample;
                     }
                 }
-                /* Reverse Substitution Process*/
+                /* Reverse Substitution Process */
                 if(nbr_id_from_bl)
                 {
                     /* Replicate the bottom-left and subsequent unavailable pixels with the 1st available pixel above */
@@ -500,9 +499,9 @@ void ihevc_hbd_intra_pred_chroma_ref_substitution(UWORD16 *pu2_top_left,
             {
                 /* To Obtain the next unavailable idx flag after reverse neighbor substitution  */
                 /* Divide by 4 to obtain the original index */
-                frwd_nbr_flag = (nbr_id_from_bl >> (chroma_format_idc == CHROMA_FMT_IDC_YUV444 ? 3 : 2));/*+ (nbr_id_from_bl & 0x1);*/
+                frwd_nbr_flag = (nbr_id_from_bl >> (chroma_format_idc == CHROMA_FMT_IDC_YUV444 ? 3 : 2));
 
-                /* The Top-left flag is at the last bit location of nbr_flags*/
+                /* The Top-left flag is at the last bit location of nbr_flags */
                 if(nbr_id_from_bl == (T16C_4NT * sub_sample / 2))
                 {
                     get_bits = GET_BIT(nbr_flags, 16);
@@ -707,7 +706,7 @@ void ihevc_hbd_intra_pred_chroma_dc(UWORD16 *pu2_ref,
     dc_val_u = (acc_dc_u + nt) >> (log2nt + 1);
     dc_val_v = (acc_dc_v + nt) >> (log2nt + 1);
 
-    /* Fill the remaining rows with DC value*/
+    /* Fill the remaining rows with DC value */
     for(row = 0; row < nt; row++)
     {
         for(col = 0; col < (2 * nt); col+=2)
@@ -766,7 +765,7 @@ void ihevc_hbd_intra_pred_chroma_horz(UWORD16 *pu2_ref,
 {
     WORD32 row, col;
 
-    /* Replication to next rows*/
+    /* Replication to next rows */
     for(row = 0; row < nt ; row++)
     {
         for(col = 0; col < (2 * nt); col+=2)
@@ -826,7 +825,7 @@ void ihevc_hbd_intra_pred_chroma_ver(UWORD16 *pu2_ref,
 {
     WORD32 row, col;
 
-    /* Replication to next columns*/
+    /* Replication to next columns */
     for(row = 0; row < nt; row++)
     {
         for(col =0; col < (2 * nt); col+=2)
@@ -952,7 +951,7 @@ void ihevc_hbd_intra_pred_chroma_mode_18_34(UWORD16 *pu2_ref,
     WORD32 intra_pred_ang;
     WORD32 idx = 0;
 
-    intra_pred_ang = 32; /*Default value*/
+    intra_pred_ang = 32; /* Default value */
     /* For mode 18, angle is -45degree */
     if(mode == 18)
     {
@@ -964,7 +963,7 @@ void ihevc_hbd_intra_pred_chroma_mode_18_34(UWORD16 *pu2_ref,
         intra_pred_ang = 32;
     }
     /* For the angle 45 and -45, replication is done from the corresponding angle */
-    /* No interpolation is done for 45 degree*/
+    /* No interpolation is done for 45 degree */
     for(row = 0; row < nt; row++)
     {
         idx = ((row + 1) * intra_pred_ang) >> 5;
@@ -1109,9 +1108,9 @@ void ihevc_hbd_intra_pred_chroma_mode_11_to_17(UWORD16 *pu2_ref,
                                                WORD32 nt,
                                                WORD32 mode)
 {
-    /* This function and ihevc_intra_pred_CHROMA_mode_19_to_25 are same except*/
+    /* This function and ihevc_intra_pred_CHROMA_mode_19_to_25 are same except */
     /* for ref main & side samples assignment,can be combined for */
-    /* optimzation*/
+    /* optimzation */
 
     WORD32 row, col, k;
     WORD32 intra_pred_ang, inv_ang, inv_ang_sum;
@@ -1126,7 +1125,7 @@ void ihevc_hbd_intra_pred_chroma_mode_11_to_17(UWORD16 *pu2_ref,
 
     inv_ang = gai4_ihevc_inv_ang_table[mode - 11];
     /* Intermediate reference samples for negative angle modes */
-    /* This have to be removed during optimization*/
+    /* This have to be removed during optimization */
 
     /* For horizontal modes, (ref main = ref left) (ref side = ref above) */
 
@@ -1235,7 +1234,7 @@ void ihevc_hbd_intra_pred_chroma_mode_19_to_25(UWORD16 *pu2_ref,
     inv_ang = gai4_ihevc_inv_ang_table_chroma[mode - 12];
 
     /* Intermediate reference samples for negative angle modes */
-    /* This have to be removed during optimization*/
+    /* This have to be removed during optimization */
     /* For horizontal modes, (ref main = ref above) (ref side = ref left) */
     ref_main = ref_temp + 2*nt;
     for(k = 0; k < (2 * (nt + 1)); k+=2)

--- a/common/ihevc_hbd_chroma_iquant_recon.c
+++ b/common/ihevc_hbd_chroma_iquant_recon.c
@@ -81,22 +81,22 @@
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -111,12 +111,12 @@ void ihevc_hbd_chroma_iquant_recon_4x4(WORD16 *pi2_src,
                                        UWORD16 *pu2_pred,
                                        WORD16 *pi2_dequant_coeff,
                                        UWORD16 *pu2_dst,
-                                       WORD32 i4_qp_div,/* qpscaled / 6 */
-                                       WORD32 i4_qp_rem,/* qpscaled % 6 */
-                                       WORD32 i4_src_strd,
-                                       WORD32 i4_pred_strd,
-                                       WORD32 i4_dst_strd,
-                                       WORD32 i4_zero_cols,
+                                       WORD32 qp_div, /* qpscaled / 6 */
+                                       WORD32 qp_rem, /* qpscaled % 6 */
+                                       WORD32 src_strd,
+                                       WORD32 pred_strd,
+                                       WORD32 dst_strd,
+                                       WORD32 zero_cols,
                                        UWORD8 u1_bit_depth)
 {
     WORD16 clip_limit;
@@ -124,7 +124,7 @@ void ihevc_hbd_chroma_iquant_recon_4x4(WORD16 *pi2_src,
     WORD32 i, j;
     WORD32 shift_iq;
     WORD32 trans_size;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     /* Inverse Quantization constants */
     {
         WORD32 log2_trans_size;
@@ -138,27 +138,27 @@ void ihevc_hbd_chroma_iquant_recon_4x4(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
-            clip_limit = (1 << u1_bit_depth) -1;
+            clip_limit = (1 << u1_bit_depth) - 1;
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
 
                 IQUANT_4x4(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3(( iquant_out + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3(( iquant_out + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -166,7 +166,7 @@ void ihevc_hbd_chroma_iquant_recon_4x4(WORD16 *pi2_src,
         pu2_pred += 2;
         pu2_dst += 2;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -192,22 +192,22 @@ void ihevc_hbd_chroma_iquant_recon_4x4(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 8x8 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -222,12 +222,12 @@ void ihevc_hbd_chroma_iquant_recon_8x8(WORD16 *pi2_src,
                                        UWORD16 *pu2_pred,
                                        WORD16 *pi2_dequant_coeff,
                                        UWORD16 *pu2_dst,
-                                       WORD32 i4_qp_div,/* qpscaled / 6 */
-                                       WORD32 i4_qp_rem,/* qpscaled % 6 */
-                                       WORD32 i4_src_strd,
-                                       WORD32 i4_pred_strd,
-                                       WORD32 i4_dst_strd,
-                                       WORD32 i4_zero_cols,
+                                       WORD32 qp_div, /* qpscaled / 6 */
+                                       WORD32 qp_rem, /* qpscaled % 6 */
+                                       WORD32 src_strd,
+                                       WORD32 pred_strd,
+                                       WORD32 dst_strd,
+                                       WORD32 zero_cols,
                                        UWORD8 u1_bit_depth)
 {
 
@@ -235,7 +235,7 @@ void ihevc_hbd_chroma_iquant_recon_8x8(WORD16 *pi2_src,
     /* Inverse Quant and recon */
     WORD32 i, j;
     WORD32 shift_iq;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     WORD32 trans_size;
     /* Inverse Quantization constants */
     {
@@ -250,26 +250,26 @@ void ihevc_hbd_chroma_iquant_recon_8x8(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
-            clip_limit = (1 << u1_bit_depth) -1;
+            clip_limit = (1 << u1_bit_depth) - 1;
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3( (iquant_out + pu2_pred[j*i4_pred_strd] ), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3( (iquant_out + pu2_pred[j*pred_strd] ), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -277,7 +277,7 @@ void ihevc_hbd_chroma_iquant_recon_8x8(WORD16 *pi2_src,
         pu2_pred += 2;
         pu2_dst += 2;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -303,22 +303,22 @@ void ihevc_hbd_chroma_iquant_recon_8x8(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 16x16 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -333,19 +333,19 @@ void ihevc_hbd_chroma_iquant_recon_16x16(WORD16 *pi2_src,
                                          UWORD16 *pu2_pred,
                                          WORD16 *pi2_dequant_coeff,
                                          UWORD16 *pu2_dst,
-                                         WORD32 i4_qp_div,/* qpscaled / 6 */
-                                         WORD32 i4_qp_rem,/* qpscaled % 6 */
-                                         WORD32 i4_src_strd,
-                                         WORD32 i4_pred_strd,
-                                         WORD32 i4_dst_strd,
-                                         WORD32 i4_zero_cols,
+                                         WORD32 qp_div, /* qpscaled / 6 */
+                                         WORD32 qp_rem, /* qpscaled % 6 */
+                                         WORD32 src_strd,
+                                         WORD32 pred_strd,
+                                         WORD32 dst_strd,
+                                         WORD32 zero_cols,
                                          UWORD8 u1_bit_depth)
 {
     WORD16 clip_limit;
     /* Inverse Quant and recon */
     WORD32 i, j;
     WORD32 shift_iq;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     WORD32 trans_size;
     /* Inverse Quantization constants */
     {
@@ -360,26 +360,26 @@ void ihevc_hbd_chroma_iquant_recon_16x16(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
-            clip_limit = (1 << u1_bit_depth) -1;
+            clip_limit = (1 << u1_bit_depth) - 1;
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size] * g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size] * g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3( (iquant_out + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3( (iquant_out + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -387,7 +387,7 @@ void ihevc_hbd_chroma_iquant_recon_16x16(WORD16 *pi2_src,
         pu2_pred += 2;
         pu2_dst += 2;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 

--- a/common/ihevc_hbd_chroma_itrans_recon.c
+++ b/common/ihevc_hbd_chroma_itrans_recon.c
@@ -82,19 +82,19 @@
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -109,11 +109,11 @@ void ihevc_hbd_chroma_itrans_recon_4x4(WORD16 *pi2_src,
                                        WORD16 *pi2_tmp,
                                        UWORD16 *pu2_pred,
                                        UWORD16 *pu2_dst,
-                                       WORD32 i4_src_strd,
-                                       WORD32 i4_pred_strd,
-                                       WORD32 i4_dst_strd,
-                                       WORD32 i4_zero_cols,
-                                       WORD32 i4_zero_rows,
+                                       WORD32 src_strd,
+                                       WORD32 pred_strd,
+                                       WORD32 dst_strd,
+                                       WORD32 zero_cols,
+                                       WORD32 zero_rows,
                                        UWORD8 u1_bit_depth)
 {
     WORD32 j;
@@ -135,21 +135,21 @@ void ihevc_hbd_chroma_itrans_recon_4x4(WORD16 *pi2_src,
     for(j = 0; j < trans_size; j++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
         }
         else
         {
             /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
-            o[0] = g_ai2_ihevc_trans_4[1][0] * pi2_src[i4_src_strd]
-                            + g_ai2_ihevc_trans_4[3][0] * pi2_src[3 * i4_src_strd];
-            o[1] = g_ai2_ihevc_trans_4[1][1] * pi2_src[i4_src_strd]
-                            + g_ai2_ihevc_trans_4[3][1] * pi2_src[3 * i4_src_strd];
+            o[0] = g_ai2_ihevc_trans_4[1][0] * pi2_src[src_strd]
+                            + g_ai2_ihevc_trans_4[3][0] * pi2_src[3 * src_strd];
+            o[1] = g_ai2_ihevc_trans_4[1][1] * pi2_src[src_strd]
+                            + g_ai2_ihevc_trans_4[3][1] * pi2_src[3 * src_strd];
             e[0] = g_ai2_ihevc_trans_4[0][0] * pi2_src[0]
-                            + g_ai2_ihevc_trans_4[2][0] * pi2_src[2 * i4_src_strd];
+                            + g_ai2_ihevc_trans_4[2][0] * pi2_src[2 * src_strd];
             e[1] = g_ai2_ihevc_trans_4[0][1] * pi2_src[0]
-                            + g_ai2_ihevc_trans_4[2][1] * pi2_src[2 * i4_src_strd];
+                            + g_ai2_ihevc_trans_4[2][1] * pi2_src[2 * src_strd];
 
             pi2_tmp[0] =
                             CLIP_S16( ((e[0] + o[0] + add)>>shift) );
@@ -162,7 +162,7 @@ void ihevc_hbd_chroma_itrans_recon_4x4(WORD16 *pi2_src,
         }
         pi2_src++;
         pi2_tmp += trans_size;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 
     pi2_tmp = pi2_tmp_orig;
@@ -170,7 +170,7 @@ void ihevc_hbd_chroma_itrans_recon_4x4(WORD16 *pi2_src,
     /* Inverse Transform 2nd stage */
     shift = 20 - u1_bit_depth;
     add = 1 << (shift - 1);
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(j = 0; j < trans_size; j++)
     {
@@ -199,7 +199,7 @@ void ihevc_hbd_chroma_itrans_recon_4x4(WORD16 *pi2_src,
         pu2_dst[3 * 2] = CLIP3( (itrans_out + pu2_pred[3 * 2] ), 0, clip_limit);
 
         pi2_tmp++;
-        pu2_pred += i4_pred_strd;
-        pu2_dst += i4_dst_strd;
+        pu2_pred += pred_strd;
+        pu2_dst += dst_strd;
     }
 }

--- a/common/ihevc_hbd_chroma_itrans_recon_16x16.c
+++ b/common/ihevc_hbd_chroma_itrans_recon_16x16.c
@@ -81,19 +81,19 @@
  * @param[out] pu2_dst
  *  Output 16x16 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -107,11 +107,11 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                                          WORD16 *pi2_tmp,
                                          UWORD16 *pu2_pred,
                                          UWORD16 *pu2_dst,
-                                         WORD32 i4_src_strd,
-                                         WORD32 i4_pred_strd,
-                                         WORD32 i4_dst_strd,
-                                         WORD32 i4_zero_cols,
-                                         WORD32 i4_zero_rows,
+                                         WORD32 src_strd,
+                                         WORD32 pred_strd,
+                                         WORD32 dst_strd,
+                                         WORD32 zero_cols,
+                                         WORD32 zero_rows,
                                          UWORD8 u1_bit_depth)
 {
     WORD32 j, k;
@@ -123,20 +123,20 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
     WORD16 *pi2_tmp_orig;
     WORD32 trans_size;
     WORD16 clip_limit;
-    WORD32 row_limit_2nd_stage, zero_rows_2nd_stage = i4_zero_cols;
+    WORD32 row_limit_2nd_stage, zero_rows_2nd_stage = zero_cols;
 
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
     trans_size = TRANS_SIZE_16;
     pi2_tmp_orig = pi2_tmp;
 
-    if((i4_zero_cols & 0xFFF0) == 0xFFF0)
+    if((zero_cols & 0xFFF0) == 0xFFF0)
         row_limit_2nd_stage = 4;
-    else if((i4_zero_cols & 0xFF00) == 0xFF00)
+    else if((zero_cols & 0xFF00) == 0xFF00)
         row_limit_2nd_stage = 8;
     else
         row_limit_2nd_stage = TRANS_SIZE_16;
 
-    if((i4_zero_rows & 0xFFF0) == 0xFFF0) /* First 4 rows of input are non-zero */
+    if((zero_rows & 0xFFF0) == 0xFFF0) /* First 4 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_16x16****************************************/
@@ -149,7 +149,7 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -158,13 +158,13 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 8; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_16[3][k]
-                                                    * pi2_src[3 * i4_src_strd];
+                                                    * pi2_src[3 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * i4_src_strd];
+                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * src_strd];
                 }
                 eeo[0] = 0;
                 eee[0] = g_ai2_ihevc_trans_16[0][0] * pi2_src[0];
@@ -192,7 +192,7 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -242,8 +242,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFF00) == 0xFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -294,8 +294,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -364,15 +364,15 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
         /************************************END - IT_RECON_16x16****************************************/
         /************************************************************************************************/
     }
-    else if((i4_zero_rows & 0xFF00) == 0xFF00) /* First 8 rows of input are non-zero */
+    else if((zero_rows & 0xFF00) == 0xFF00) /* First 8 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_16x16****************************************/
@@ -385,7 +385,7 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -394,23 +394,23 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 8; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_16[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_16[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_16[7][k]
-                                                    * pi2_src[7 * i4_src_strd];
+                                                    * pi2_src[7 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * src_strd]
                                     + g_ai2_ihevc_trans_16[6][k]
-                                                    * pi2_src[6 * i4_src_strd];
+                                                    * pi2_src[6 * src_strd];
                 }
-                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * i4_src_strd];
+                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * src_strd];
                 eee[0] = g_ai2_ihevc_trans_16[0][0] * pi2_src[0];
-                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * i4_src_strd];
+                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * src_strd];
                 eee[1] = g_ai2_ihevc_trans_16[0][1] * pi2_src[0];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
@@ -434,7 +434,7 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -484,8 +484,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFF00) == 0xFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -536,8 +536,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -606,8 +606,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
@@ -627,7 +627,7 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -636,44 +636,44 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 8; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_16[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_16[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_16[7][k]
-                                                    * pi2_src[7 * i4_src_strd]
+                                                    * pi2_src[7 * src_strd]
                                     + g_ai2_ihevc_trans_16[9][k]
-                                                    * pi2_src[9 * i4_src_strd]
+                                                    * pi2_src[9 * src_strd]
                                     + g_ai2_ihevc_trans_16[11][k]
-                                                    * pi2_src[11 * i4_src_strd]
+                                                    * pi2_src[11 * src_strd]
                                     + g_ai2_ihevc_trans_16[13][k]
-                                                    * pi2_src[13 * i4_src_strd]
+                                                    * pi2_src[13 * src_strd]
                                     + g_ai2_ihevc_trans_16[15][k]
-                                                    * pi2_src[15 * i4_src_strd];
+                                                    * pi2_src[15 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * src_strd]
                                     + g_ai2_ihevc_trans_16[6][k]
-                                                    * pi2_src[6 * i4_src_strd]
+                                                    * pi2_src[6 * src_strd]
                                     + g_ai2_ihevc_trans_16[10][k]
-                                                    * pi2_src[10 * i4_src_strd]
+                                                    * pi2_src[10 * src_strd]
                                     + g_ai2_ihevc_trans_16[14][k]
-                                                    * pi2_src[14 * i4_src_strd];
+                                                    * pi2_src[14 * src_strd];
                 }
-                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * i4_src_strd]
+                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * src_strd]
                                     + g_ai2_ihevc_trans_16[12][0]
-                                                    * pi2_src[12 * i4_src_strd];
+                                                    * pi2_src[12 * src_strd];
                 eee[0] = g_ai2_ihevc_trans_16[0][0] * pi2_src[0]
                                     + g_ai2_ihevc_trans_16[8][0]
-                                                    * pi2_src[8 * i4_src_strd];
-                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * i4_src_strd]
+                                                    * pi2_src[8 * src_strd];
+                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * src_strd]
                                     + g_ai2_ihevc_trans_16[12][1]
-                                                    * pi2_src[12 * i4_src_strd];
+                                                    * pi2_src[12 * src_strd];
                 eee[1] = g_ai2_ihevc_trans_16[0][1] * pi2_src[0]
                                     + g_ai2_ihevc_trans_16[8][1]
-                                                    * pi2_src[8 * i4_src_strd];
+                                                    * pi2_src[8 * src_strd];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
                 for(k = 0; k < 2; k++)
@@ -696,7 +696,7 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -746,8 +746,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFF00) == 0xFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -798,8 +798,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -868,8 +868,8 @@ void ihevc_hbd_chroma_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[(k + 8) * 2] = CLIP3((itrans_out + pu2_pred[(k + 8) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/

--- a/common/ihevc_hbd_chroma_itrans_recon_32x32.c
+++ b/common/ihevc_hbd_chroma_itrans_recon_32x32.c
@@ -73,19 +73,19 @@
   * @param[out] pu2_dst
   *  Output 32x32 block
   *
-  * @param[in] i4_src_strd
+  * @param[in] src_strd
   *  Input stride
   *
-  * @param[in] i4_pred_strd
+  * @param[in] pred_strd
   *  Prediction stride
   *
-  * @param[in] i4_dst_strd
+  * @param[in] dst_strd
   *  Output Stride
   *
   * @param[in] shift
   *  Output shift
   *
-  * @param[in] i4_zero_cols
+  * @param[in] zero_cols
   *  Zero columns in pi2_src
   *
   * @returns  Void
@@ -99,11 +99,11 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                                          WORD16 *pi2_tmp,
                                          UWORD16 *pu2_pred,
                                          UWORD16 *pu2_dst,
-                                         WORD32 i4_src_strd,
-                                         WORD32 i4_pred_strd,
-                                         WORD32 i4_dst_strd,
-                                         WORD32 i4_zero_cols,
-                                         WORD32 i4_zero_rows,
+                                         WORD32 src_strd,
+                                         WORD32 pred_strd,
+                                         WORD32 dst_strd,
+                                         WORD32 zero_cols,
+                                         WORD32 zero_rows,
                                          UWORD8 u1_bit_depth)
 {
     WORD32 j, k;
@@ -115,7 +115,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
     WORD32 shift;
     WORD16 *pi2_tmp_orig;
     WORD32 trans_size;
-    WORD32 zero_rows_2nd_stage = i4_zero_cols;
+    WORD32 zero_rows_2nd_stage = zero_cols;
     WORD32 row_limit_2nd_stage;
     WORD16 clip_limit;
 
@@ -123,14 +123,14 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
     pi2_tmp_orig = pi2_tmp;
     clip_limit = (1 << u1_bit_depth) - 1;
 
-    if((i4_zero_cols & 0xFFFFFFF0) == 0xFFFFFFF0)
+    if((zero_cols & 0xFFFFFFF0) == 0xFFFFFFF0)
         row_limit_2nd_stage = 4;
-    else if((i4_zero_cols & 0xFFFFFF00) == 0xFFFFFF00)
+    else if((zero_cols & 0xFFFFFF00) == 0xFFFFFF00)
         row_limit_2nd_stage = 8;
     else
         row_limit_2nd_stage = TRANS_SIZE_32;
 
-    if((i4_zero_rows & 0xFFFFFFF0) == 0xFFFFFFF0)  /* First 4 rows of input are non-zero */
+    if((zero_rows & 0xFFFFFFF0) == 0xFFFFFFF0)  /* First 4 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_32x32****************************************/
@@ -142,7 +142,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -151,13 +151,13 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 16; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[src_strd]
                         + g_ai2_ihevc_trans_32[3][k]
-                        * pi2_src[3 * i4_src_strd];
+                        * pi2_src[3 * src_strd];
                 }
                 for(k = 0; k < 8; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * i4_src_strd];
+                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * src_strd];
                 }
                 {
                     eeo[0] = 0;
@@ -195,7 +195,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -255,8 +255,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -315,8 +315,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -433,15 +433,15 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
         /************************************END - IT_RECON_32x32****************************************/
         /************************************************************************************************/
     }
-    else if((i4_zero_rows & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of input are non-zero */
+    else if((zero_rows & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_32x32****************************************/
@@ -453,7 +453,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -462,23 +462,23 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 16; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[src_strd]
                         + g_ai2_ihevc_trans_32[3][k]
-                        * pi2_src[3 * i4_src_strd]
+                        * pi2_src[3 * src_strd]
                         + g_ai2_ihevc_trans_32[5][k]
-                        * pi2_src[5 * i4_src_strd]
+                        * pi2_src[5 * src_strd]
                         + g_ai2_ihevc_trans_32[7][k]
-                        * pi2_src[7 * i4_src_strd];
+                        * pi2_src[7 * src_strd];
                 }
                 for(k = 0; k < 8; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * src_strd]
                         + g_ai2_ihevc_trans_32[6][k]
-                        * pi2_src[6 * i4_src_strd];
+                        * pi2_src[6 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * i4_src_strd];
+                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * src_strd];
                 }
                 eeeo[0] = 0;
                 eeeo[1] = 0;
@@ -510,7 +510,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -570,8 +570,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -630,8 +630,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -748,8 +748,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
@@ -768,7 +768,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -777,78 +777,78 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 16; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[src_strd]
                         + g_ai2_ihevc_trans_32[3][k]
-                        * pi2_src[3 * i4_src_strd]
+                        * pi2_src[3 * src_strd]
                         + g_ai2_ihevc_trans_32[5][k]
-                        * pi2_src[5 * i4_src_strd]
+                        * pi2_src[5 * src_strd]
                         + g_ai2_ihevc_trans_32[7][k]
-                        * pi2_src[7 * i4_src_strd]
+                        * pi2_src[7 * src_strd]
                         + g_ai2_ihevc_trans_32[9][k]
-                        * pi2_src[9 * i4_src_strd]
+                        * pi2_src[9 * src_strd]
                         + g_ai2_ihevc_trans_32[11][k]
-                        * pi2_src[11 * i4_src_strd]
+                        * pi2_src[11 * src_strd]
                         + g_ai2_ihevc_trans_32[13][k]
-                        * pi2_src[13 * i4_src_strd]
+                        * pi2_src[13 * src_strd]
                         + g_ai2_ihevc_trans_32[15][k]
-                        * pi2_src[15 * i4_src_strd]
+                        * pi2_src[15 * src_strd]
                         + g_ai2_ihevc_trans_32[17][k]
-                        * pi2_src[17 * i4_src_strd]
+                        * pi2_src[17 * src_strd]
                         + g_ai2_ihevc_trans_32[19][k]
-                        * pi2_src[19 * i4_src_strd]
+                        * pi2_src[19 * src_strd]
                         + g_ai2_ihevc_trans_32[21][k]
-                        * pi2_src[21 * i4_src_strd]
+                        * pi2_src[21 * src_strd]
                         + g_ai2_ihevc_trans_32[23][k]
-                        * pi2_src[23 * i4_src_strd]
+                        * pi2_src[23 * src_strd]
                         + g_ai2_ihevc_trans_32[25][k]
-                        * pi2_src[25 * i4_src_strd]
+                        * pi2_src[25 * src_strd]
                         + g_ai2_ihevc_trans_32[27][k]
-                        * pi2_src[27 * i4_src_strd]
+                        * pi2_src[27 * src_strd]
                         + g_ai2_ihevc_trans_32[29][k]
-                        * pi2_src[29 * i4_src_strd]
+                        * pi2_src[29 * src_strd]
                         + g_ai2_ihevc_trans_32[31][k]
-                        * pi2_src[31 * i4_src_strd];
+                        * pi2_src[31 * src_strd];
                 }
                 for(k = 0; k < 8; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * src_strd]
                         + g_ai2_ihevc_trans_32[6][k]
-                        * pi2_src[6 * i4_src_strd]
+                        * pi2_src[6 * src_strd]
                         + g_ai2_ihevc_trans_32[10][k]
-                        * pi2_src[10 * i4_src_strd]
+                        * pi2_src[10 * src_strd]
                         + g_ai2_ihevc_trans_32[14][k]
-                        * pi2_src[14 * i4_src_strd]
+                        * pi2_src[14 * src_strd]
                         + g_ai2_ihevc_trans_32[18][k]
-                        * pi2_src[18 * i4_src_strd]
+                        * pi2_src[18 * src_strd]
                         + g_ai2_ihevc_trans_32[22][k]
-                        * pi2_src[22 * i4_src_strd]
+                        * pi2_src[22 * src_strd]
                         + g_ai2_ihevc_trans_32[26][k]
-                        * pi2_src[26 * i4_src_strd]
+                        * pi2_src[26 * src_strd]
                         + g_ai2_ihevc_trans_32[30][k]
-                        * pi2_src[30 * i4_src_strd];
+                        * pi2_src[30 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * i4_src_strd]
+                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * src_strd]
                         + g_ai2_ihevc_trans_32[12][k]
-                        * pi2_src[12 * i4_src_strd]
+                        * pi2_src[12 * src_strd]
                         + g_ai2_ihevc_trans_32[20][k]
-                        * pi2_src[20 * i4_src_strd]
+                        * pi2_src[20 * src_strd]
                         + g_ai2_ihevc_trans_32[28][k]
-                        * pi2_src[28 * i4_src_strd];
+                        * pi2_src[28 * src_strd];
                 }
-                eeeo[0] = g_ai2_ihevc_trans_32[8][0] * pi2_src[8 * i4_src_strd]
+                eeeo[0] = g_ai2_ihevc_trans_32[8][0] * pi2_src[8 * src_strd]
                     + g_ai2_ihevc_trans_32[24][0]
-                    * pi2_src[24 * i4_src_strd];
-                eeeo[1] = g_ai2_ihevc_trans_32[8][1] * pi2_src[8 * i4_src_strd]
+                    * pi2_src[24 * src_strd];
+                eeeo[1] = g_ai2_ihevc_trans_32[8][1] * pi2_src[8 * src_strd]
                     + g_ai2_ihevc_trans_32[24][1]
-                    * pi2_src[24 * i4_src_strd];
+                    * pi2_src[24 * src_strd];
                 eeee[0] = g_ai2_ihevc_trans_32[0][0] * pi2_src[0]
                     + g_ai2_ihevc_trans_32[16][0]
-                    * pi2_src[16 * i4_src_strd];
+                    * pi2_src[16 * src_strd];
                 eeee[1] = g_ai2_ihevc_trans_32[0][1] * pi2_src[0]
                     + g_ai2_ihevc_trans_32[16][1]
-                    * pi2_src[16 * i4_src_strd];
+                    * pi2_src[16 * src_strd];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
                 eee[0] = eeee[0] + eeeo[0];
@@ -875,7 +875,7 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -935,8 +935,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -995,8 +995,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -1113,8 +1113,8 @@ void ihevc_hbd_chroma_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[(k + 16) * 2] = CLIP3((itrans_out + pu2_pred[(k + 16) * 2]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/

--- a/common/ihevc_hbd_chroma_itrans_recon_8x8.c
+++ b/common/ihevc_hbd_chroma_itrans_recon_8x8.c
@@ -80,19 +80,19 @@
  * @param[out] pu2_dst
  *  Output 8x8 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -106,11 +106,11 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
                                        WORD16 *pi2_tmp,
                                        UWORD16 *pu2_pred,
                                        UWORD16 *pu2_dst,
-                                       WORD32 i4_src_strd,
-                                       WORD32 i4_pred_strd,
-                                       WORD32 i4_dst_strd,
-                                       WORD32 i4_zero_cols,
-                                       WORD32 i4_zero_rows,
+                                       WORD32 src_strd,
+                                       WORD32 pred_strd,
+                                       WORD32 dst_strd,
+                                       WORD32 zero_cols,
+                                       WORD32 zero_rows,
                                        UWORD8 u1_bit_depth)
 {
     WORD32 j, k;
@@ -120,16 +120,16 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
     WORD32 shift;
     WORD16 *pi2_tmp_orig;
     WORD32 trans_size;
-    WORD32 zero_rows_2nd_stage = i4_zero_cols;
+    WORD32 zero_rows_2nd_stage = zero_cols;
     WORD32 row_limit_2nd_stage;
     WORD16 clip_limit;
 
     trans_size = TRANS_SIZE_8;
 
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
     pi2_tmp_orig = pi2_tmp;
 
-    if((i4_zero_cols & 0xF0) == 0xF0)
+    if((zero_cols & 0xF0) == 0xF0)
         row_limit_2nd_stage = 4;
     else
         row_limit_2nd_stage = TRANS_SIZE_8;
@@ -145,7 +145,7 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -154,23 +154,23 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 4; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_8[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_8[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_8[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_8[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_8[7][k]
-                                                    * pi2_src[7 * i4_src_strd];
+                                                    * pi2_src[7 * src_strd];
                 }
 
-                eo[0] = g_ai2_ihevc_trans_8[2][0] * pi2_src[2 * i4_src_strd]
-                                + g_ai2_ihevc_trans_8[6][0] * pi2_src[6 * i4_src_strd];
-                eo[1] = g_ai2_ihevc_trans_8[2][1] * pi2_src[2 * i4_src_strd]
-                                + g_ai2_ihevc_trans_8[6][1] * pi2_src[6 * i4_src_strd];
+                eo[0] = g_ai2_ihevc_trans_8[2][0] * pi2_src[2 * src_strd]
+                                + g_ai2_ihevc_trans_8[6][0] * pi2_src[6 * src_strd];
+                eo[1] = g_ai2_ihevc_trans_8[2][1] * pi2_src[2 * src_strd]
+                                + g_ai2_ihevc_trans_8[6][1] * pi2_src[6 * src_strd];
                 ee[0] = g_ai2_ihevc_trans_8[0][0] * pi2_src[0]
-                                + g_ai2_ihevc_trans_8[4][0] * pi2_src[4 * i4_src_strd];
+                                + g_ai2_ihevc_trans_8[4][0] * pi2_src[4 * src_strd];
                 ee[1] = g_ai2_ihevc_trans_8[0][1] * pi2_src[0]
-                                + g_ai2_ihevc_trans_8[4][1] * pi2_src[4 * i4_src_strd];
+                                + g_ai2_ihevc_trans_8[4][1] * pi2_src[4 * src_strd];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
                 e[0] = ee[0] + eo[0];
@@ -187,7 +187,7 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -229,8 +229,8 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
                                     CLIP3((itrans_out + pu2_pred[(k + 4) * 2] ), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -275,8 +275,8 @@ void ihevc_hbd_chroma_itrans_recon_8x8(WORD16 *pi2_src,
                                     CLIP3((itrans_out + pu2_pred[(k + 4) * 2] ), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/

--- a/common/ihevc_hbd_chroma_recon.c
+++ b/common/ihevc_hbd_chroma_recon.c
@@ -76,19 +76,19 @@
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -102,10 +102,10 @@
 void ihevc_hbd_chroma_recon_4x4(WORD16 *pi2_src,
                                 UWORD16 *pu2_pred,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
                                 UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -119,25 +119,25 @@ void ihevc_hbd_chroma_recon_4x4(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3((pi2_src[j * i4_src_strd] + pu2_pred[j * i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3((pi2_src[j * src_strd] + pu2_pred[j * pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst += 2;
         pu2_pred += 2;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -159,19 +159,19 @@ void ihevc_hbd_chroma_recon_4x4(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 8x8 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -185,10 +185,10 @@ void ihevc_hbd_chroma_recon_4x4(WORD16 *pi2_src,
 void ihevc_hbd_chroma_recon_8x8(WORD16 *pi2_src,
                                 UWORD16 *pu2_pred,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
                                 UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -202,25 +202,25 @@ void ihevc_hbd_chroma_recon_8x8(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3((pi2_src[j * i4_src_strd] + pu2_pred[j * i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3((pi2_src[j * src_strd] + pu2_pred[j * pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst += 2;
         pu2_pred += 2;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -242,19 +242,19 @@ void ihevc_hbd_chroma_recon_8x8(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 16x16 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -268,10 +268,10 @@ void ihevc_hbd_chroma_recon_8x8(WORD16 *pi2_src,
 void ihevc_hbd_chroma_recon_16x16(WORD16 *pi2_src,
                                   UWORD16 *pu2_pred,
                                   UWORD16 *pu2_dst,
-                                  WORD32 i4_src_strd,
-                                  WORD32 i4_pred_strd,
-                                  WORD32 i4_dst_strd,
-                                  WORD32 i4_zero_cols,
+                                  WORD32 src_strd,
+                                  WORD32 pred_strd,
+                                  WORD32 dst_strd,
+                                  WORD32 zero_cols,
                                   UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -285,25 +285,25 @@ void ihevc_hbd_chroma_recon_16x16(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3((pi2_src[j * i4_src_strd] + pu2_pred[j * i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3((pi2_src[j * src_strd] + pu2_pred[j * pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst += 2;
         pu2_pred += 2;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 
@@ -326,19 +326,19 @@ void ihevc_hbd_chroma_recon_16x16(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 32x32 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -352,10 +352,10 @@ void ihevc_hbd_chroma_recon_16x16(WORD16 *pi2_src,
 void ihevc_hbd_chroma_recon_32x32(WORD16 *pi2_src,
                                   UWORD16 *pu2_pred,
                                   UWORD16 *pu2_dst,
-                                  WORD32 i4_src_strd,
-                                  WORD32 i4_pred_strd,
-                                  WORD32 i4_dst_strd,
-                                  WORD32 i4_zero_cols,
+                                  WORD32 src_strd,
+                                  WORD32 pred_strd,
+                                  WORD32 dst_strd,
+                                  WORD32 zero_cols,
                                   UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -369,25 +369,25 @@ void ihevc_hbd_chroma_recon_32x32(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3((pi2_src[j * i4_src_strd] + pu2_pred[j * i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3((pi2_src[j * src_strd] + pu2_pred[j * pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst += 2;
         pu2_pred += 2;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 
@@ -420,10 +420,10 @@ void ihevc_hbd_chroma_recon_32x32(WORD16 *pi2_src,
  * @param[in]   trans_size
  * transform size
  *
- * @param[in]   luma_res_stride
+ * @param[in]   luma_res_strd
  * stride of the luma residual buffer
  *
- * @param[in]   chroma_res_stride
+ * @param[in]   chroma_res_strd
  * stride of the chroma residual buffer
  *
  * @param[in] pred_strd
@@ -445,10 +445,10 @@ void ihevc_hbd_chroma_recon_nxn_ccp(WORD16 *pi2_luma_res,
                                     UWORD16 *pu2_dst,
                                     WORD32 alpha,
                                     WORD32 trans_size,
-                                    WORD32 luma_res_stride,
-                                    WORD32 chroma_res_stride,
-                                    WORD32 pred_stride,
-                                    WORD32 dst_stride,
+                                    WORD32 luma_res_strd,
+                                    WORD32 chroma_res_strd,
+                                    WORD32 pred_strd,
+                                    WORD32 dst_strd,
                                     UWORD8 bit_depth)
 {
     WORD32 i, j;
@@ -461,9 +461,9 @@ void ihevc_hbd_chroma_recon_nxn_ccp(WORD16 *pi2_luma_res,
             WORD32 res = (alpha * pi2_luma_res[j]) >> 3;
             pu2_dst[j * 2] = CLIP3((pu2_pred[j * 2] + pi2_chroma_res[j] + res), 0, clip_limit);
         }
-        pi2_luma_res += luma_res_stride;
-        pi2_chroma_res += chroma_res_stride;
-        pu2_dst += dst_stride;
-        pu2_pred += pred_stride;
+        pi2_luma_res += luma_res_strd;
+        pi2_chroma_res += chroma_res_strd;
+        pu2_dst += dst_strd;
+        pu2_pred += pred_strd;
     }
 }

--- a/common/ihevc_hbd_inter_pred_filters.c
+++ b/common/ihevc_hbd_inter_pred_filters.c
@@ -178,19 +178,19 @@ void ihevc_hbd_inter_pred_luma_horz(UWORD16 *pu2_src,
                                     UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_LUMA; i++)
-                i4_tmp += pi1_coeff[i] * pu2_src[col + (i - 3)];
+                tmp += pi1_coeff[i] * pu2_src[col + (i - 3)];
 
-            i4_tmp = (i4_tmp + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
-            i4_tmp = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
-            pu2_dst[col] = (UWORD16)i4_tmp;
+            tmp = (tmp + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp = CLIP3(tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = (UWORD16)tmp;
         }
 
         pu2_src += src_strd;
@@ -250,19 +250,19 @@ void ihevc_hbd_inter_pred_luma_vert(UWORD16 *pu2_src,
                                     UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_LUMA; i++)
-                i4_tmp += pi1_coeff[i] * pu2_src[col + (i - 3) * src_strd];
+                tmp += pi1_coeff[i] * pu2_src[col + (i - 3) * src_strd];
 
-            i4_tmp = (i4_tmp + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
-            i4_tmp = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
-            pu2_dst[col] = (UWORD16)i4_tmp;
+            tmp = (tmp + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp = CLIP3(tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = (UWORD16)tmp;
         }
 
         pu2_src += src_strd;
@@ -388,16 +388,16 @@ void ihevc_hbd_inter_pred_luma_horz_w16out(UWORD16 *pu2_src,
                                            UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_LUMA; i++)
-                i4_tmp += pi1_coeff[i] * pu2_src[col + (i - 3)];
-            pi2_dst[col] = i4_tmp >> (FILTER_PREC - (14-bit_depth));
+                tmp += pi1_coeff[i] * pu2_src[col + (i - 3)];
+            pi2_dst[col] = tmp >> (FILTER_PREC - (14-bit_depth));
         }
 
         pu2_src += src_strd;
@@ -458,17 +458,17 @@ void ihevc_hbd_inter_pred_luma_vert_w16out(UWORD16 *pu2_src,
                                            UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_LUMA; i++)
-                i4_tmp += pi1_coeff[i] * pu2_src[col + (i - 3) * src_strd];
+                tmp += pi1_coeff[i] * pu2_src[col + (i - 3) * src_strd];
 
-            pi2_dst[col] = i4_tmp >> (FILTER_PREC - (14-bit_depth));
+            pi2_dst[col] = tmp >> (FILTER_PREC - (14-bit_depth));
         }
 
         pu2_src += src_strd;
@@ -528,19 +528,19 @@ void ihevc_hbd_inter_pred_luma_vert_w16inp(WORD16 *pi2_src,
                                            UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_LUMA; i++)
-                i4_tmp += pi1_coeff[i] * pi2_src[col + (i - 3) * src_strd];
+                tmp += pi1_coeff[i] * pi2_src[col + (i - 3) * src_strd];
 
-            i4_tmp = ((i4_tmp >> (14-bit_depth)) + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp = ((tmp >> (14-bit_depth)) + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
 
-            i4_tmp = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
-            pu2_dst[col] = i4_tmp;
+            tmp = CLIP3(tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = tmp;
         }
 
         pi2_src += src_strd;
@@ -602,18 +602,18 @@ void ihevc_hbd_inter_pred_luma_vert_w16inp_w16out(WORD16 *pi2_src,
                                                   UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_LUMA; i++)
-                i4_tmp += pi1_coeff[i] * pi2_src[col + (i - 3) * src_strd];
-            i4_tmp = (i4_tmp >> FILTER_PREC) - OFFSET14;
+                tmp += pi1_coeff[i] * pi2_src[col + (i - 3) * src_strd];
+            tmp = (tmp >> FILTER_PREC) - OFFSET14;
 
-            pi2_dst[col] = i4_tmp;
+            pi2_dst[col] = tmp;
         }
 
         pi2_src += src_strd;
@@ -739,28 +739,28 @@ void ihevc_hbd_inter_pred_chroma_horz(UWORD16 *pu2_src,
                                       UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp_u, i4_tmp_v;
+    WORD32 tmp_u, tmp_v;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2*wd; col+=2)
         {
-            i4_tmp_u = 0;
-            i4_tmp_v = 0;
+            tmp_u = 0;
+            tmp_v = 0;
             for(i = 0; i < NTAPS_CHROMA; i++)
             {
-                i4_tmp_u += pi1_coeff[i] * pu2_src[col + (i-1)*2];
-                i4_tmp_v += pi1_coeff[i] * pu2_src[col + 1 + (i-1)*2];
+                tmp_u += pi1_coeff[i] * pu2_src[col + (i-1)*2];
+                tmp_v += pi1_coeff[i] * pu2_src[col + 1 + (i-1)*2];
             }
 
-            i4_tmp_u = (i4_tmp_u + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
-            i4_tmp_v = (i4_tmp_v + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp_u = (tmp_u + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp_v = (tmp_v + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
 
-            i4_tmp_u = CLIP3(i4_tmp_u,0,((1<<bit_depth)-1));
-            i4_tmp_v = CLIP3(i4_tmp_v,0,((1<<bit_depth)-1));
+            tmp_u = CLIP3(tmp_u,0,((1<<bit_depth)-1));
+            tmp_v = CLIP3(tmp_v,0,((1<<bit_depth)-1));
 
-            pu2_dst[col] = (UWORD16)i4_tmp_u;
-            pu2_dst[col + 1] = (UWORD16)i4_tmp_v;
+            pu2_dst[col] = (UWORD16)tmp_u;
+            pu2_dst[col + 1] = (UWORD16)tmp_v;
         }
 
         pu2_src += src_strd;
@@ -822,22 +822,22 @@ void ihevc_hbd_inter_pred_chroma_vert(UWORD16 *pu2_src,
                                       UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2 * wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_CHROMA; i++)
             {
-                i4_tmp += pi1_coeff[i] * pu2_src[col + (i-1) * src_strd];
+                tmp += pi1_coeff[i] * pu2_src[col + (i-1) * src_strd];
             }
 
-            i4_tmp = (i4_tmp + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp = (tmp + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
 
-            i4_tmp = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
-            pu2_dst[col] = (UWORD16)i4_tmp;
+            tmp = CLIP3(tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = (UWORD16)tmp;
         }
 
         pu2_src += src_strd;
@@ -965,22 +965,22 @@ void ihevc_hbd_inter_pred_chroma_horz_w16out(UWORD16 *pu2_src,
                                              UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp_u, i4_tmp_v;
+    WORD32 tmp_u, tmp_v;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2*wd; col+=2)
         {
-            i4_tmp_u = 0;
-            i4_tmp_v = 0;
+            tmp_u = 0;
+            tmp_v = 0;
             for(i = 0; i < NTAPS_CHROMA; i++)
             {
-                i4_tmp_u += pi1_coeff[i] * pu2_src[col + (i-1)*2];
-                i4_tmp_v += pi1_coeff[i] * pu2_src[col + 1 + (i-1)*2];
+                tmp_u += pi1_coeff[i] * pu2_src[col + (i-1)*2];
+                tmp_v += pi1_coeff[i] * pu2_src[col + 1 + (i-1)*2];
             }
 
-            pi2_dst[col] = i4_tmp_u >> (FILTER_PREC - (14-bit_depth));
-            pi2_dst[col + 1] = i4_tmp_v >> (FILTER_PREC - (14-bit_depth));
+            pi2_dst[col] = tmp_u >> (FILTER_PREC - (14-bit_depth));
+            pi2_dst[col + 1] = tmp_v >> (FILTER_PREC - (14-bit_depth));
         }
 
         pu2_src += src_strd;
@@ -1042,19 +1042,19 @@ void ihevc_hbd_inter_pred_chroma_vert_w16out(UWORD16 *pu2_src,
                                              UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2 * wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_CHROMA; i++)
             {
-                i4_tmp += pi1_coeff[i] * pu2_src[col + (i-1) * src_strd];
+                tmp += pi1_coeff[i] * pu2_src[col + (i-1) * src_strd];
             }
 
-            pi2_dst[col] = i4_tmp >> (FILTER_PREC - (14-bit_depth));
+            pi2_dst[col] = tmp >> (FILTER_PREC - (14-bit_depth));
         }
 
         pu2_src += src_strd;
@@ -1114,22 +1114,22 @@ void ihevc_hbd_inter_pred_chroma_vert_w16inp(WORD16 *pi2_src,
                                              UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2 * wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_CHROMA; i++)
             {
-                i4_tmp += pi1_coeff[i] * pi2_src[col + (i-1) * src_strd];
+                tmp += pi1_coeff[i] * pi2_src[col + (i-1) * src_strd];
             }
 
-            i4_tmp = ((i4_tmp >> (14-bit_depth)) + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
+            tmp = ((tmp >> (14-bit_depth)) + (1<<(FILTER_PREC-1))) >> FILTER_PREC;
 
-            i4_tmp = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
-            pu2_dst[col] = i4_tmp;
+            tmp = CLIP3(tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = tmp;
         }
 
         pi2_src += src_strd;
@@ -1191,21 +1191,21 @@ void ihevc_hbd_inter_pred_chroma_vert_w16inp_w16out(WORD16 *pi2_src,
                                                     UWORD8 bit_depth)
 {
     WORD32 row, col, i;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2 * wd; col++)
         {
-            i4_tmp = 0;
+            tmp = 0;
             for(i = 0; i < NTAPS_CHROMA; i++)
             {
-                i4_tmp += pi1_coeff[i] * pi2_src[col + (i-1) * src_strd];
+                tmp += pi1_coeff[i] * pi2_src[col + (i-1) * src_strd];
             }
 
-            i4_tmp = (i4_tmp >> FILTER_PREC);
+            tmp = (tmp >> FILTER_PREC);
 
-            pi2_dst[col] = i4_tmp;
+            pi2_dst[col] = tmp;
         }
 
         pi2_src += src_strd;

--- a/common/ihevc_hbd_intra_pred_filters.c
+++ b/common/ihevc_hbd_intra_pred_filters.c
@@ -151,7 +151,7 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
 
     dc_val = 1 << (bit_depth - 1);
 
-    /* Neighbor Flag Structure*/
+    /* Neighbor Flag Structure */
     /* MSB ---> LSB */
     /*    Top-Left | Top-Right | Top | Left | Bottom-Left
               1         4         4     4         4
@@ -227,16 +227,16 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
             }
             next = 1;
 
-            /* If bottom -left is not available, reverse substitution process*/
+            /* If bottom -left is not available, reverse substitution process */
             if(bot_left == 0)
             {
                 WORD32 a_nbr_flag[5] = { bot_left, left, tp_left, top, tp_right};
 
-                /* Check for the 1st available sample from bottom-left*/
+                /* Check for the 1st available sample from bottom-left */
                 while(!a_nbr_flag[next])
                     next++;
 
-                /* If Left, top-left are available*/
+                /* If Left, top-left are available */
                 if(next <= 2)
                 {
                     idx = nt * next;
@@ -246,7 +246,7 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
                 }
                 else /* If top, top-right are available */
                 {
-                    /* Idx is changed to copy 1 pixel value for top-left ,if top-left is not available*/
+                    /* Idx is changed to copy 1 pixel value for top-left ,if top-left is not available */
                     idx = (nt * (next - 1)) + 1;
                     pu2_ref = pu2_dst[idx];
                     for(i = 0; i < idx; i++)
@@ -336,7 +336,7 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
                 for(i = nt; i < two_nt; i++)
                     pu2_dst[two_nt + 1 + i] = 0;
             }
-            /* compute trailing zeors based on nbr_flag for substitution process of below left see section .*/
+            /* compute trailing zeors based on nbr_flag for substitution process of below left see section . */
             /* as each bit in nbr flags corresponds to 8 pels for bot_left, left, top and topright but 1 pel for topleft */
             {
                 nbr_id_from_bl = look_up_trailing_zeros(nbr_flags_temp & 0XF) * 8; /* for below left and left */
@@ -351,10 +351,9 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
                     {
                         nbr_id_from_bl++;
                         nbr_id_from_bl += look_up_trailing_zeros((nbr_flags_temp >> 4) & 0xF) * 8; /* top and top right;  8 pels per nbr bit */
-                        //nbr_id_from_bl += idx * 8;
                     }
                 }
-                /* Reverse Substitution Process*/
+                /* Reverse Substitution Process */
                 if(nbr_id_from_bl)
                 {
                     /* Replicate the bottom-left and subsequent unavailable pixels with the 1st available pixel above */
@@ -371,9 +370,9 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
             {
                 /* To Obtain the next unavailable idx flag after reverse neighbor substitution  */
                 /* Devide by 8 to obtain the original index */
-                frwd_nbr_flag = (nbr_id_from_bl >> 3);/*+ (nbr_id_from_bl & 0x1);*/
+                frwd_nbr_flag = (nbr_id_from_bl >> 3);
 
-                /* The Top-left flag is at the last bit location of nbr_flags*/
+                /* The Top-left flag is at the last bit location of nbr_flags */
                 if(nbr_id_from_bl == (T16_4NT / 2))
                 {
                     get_bits = GET_BIT(nbr_flags_temp, 8);
@@ -448,7 +447,7 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
                 for(i = nt; i < two_nt; i++)
                     pu2_dst[two_nt + 1 + i] = 0;
             }
-            /* compute trailing ones based on mbr_flag for substitution process of below left see section .*/
+            /* compute trailing ones based on mbr_flag for substitution process of below left see section . */
             /* as each bit in nbr flags corresponds to 8 pels for bot_left, left, top and topright but 1 pel for topleft */
             {
                 nbr_id_from_bl = look_up_trailing_zeros((nbr_flags & 0XFF)) * 8; /* for below left and left */
@@ -464,7 +463,7 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
                         nbr_id_from_bl += look_up_trailing_zeros((nbr_flags >> 8) & 0xFF) * 8;
                     }
                 }
-                /* Reverse Substitution Process*/
+                /* Reverse Substitution Process */
                 if(nbr_id_from_bl)
                 {
                     /* Replicate the bottom-left and subsequent unavailable pixels with the 1st available pixel above */
@@ -479,9 +478,9 @@ void ihevc_hbd_intra_pred_luma_ref_substitution(UWORD16 *pu2_top_left,
             {
                 /* To Obtain the next unavailable idx flag after reverse neighbor substitution  */
                 /* Devide by 8 to obtain the original index */
-                frwd_nbr_flag = (nbr_id_from_bl >> 3);/*+ (nbr_id_from_bl & 0x1);*/
+                frwd_nbr_flag = (nbr_id_from_bl >> 3);
 
-                /* The Top-left flag is at the last bit location of nbr_flags*/
+                /* The Top-left flag is at the last bit location of nbr_flags */
                 if(nbr_id_from_bl == (T32_4NT / 2))
                 {
                     get_bits = GET_BIT(nbr_flags, 16);
@@ -587,7 +586,7 @@ void ihevc_hbd_intra_pred_ref_filtering(UWORD16 *pu2_src,
             bi_linear_int_flag = ((1 == abs_cond_left_flag)
                                     && (1 == abs_cond_top_flag));
         }
-        /* Extremities Untouched*/
+        /* Extremities Untouched */
         au2_flt[0] = pu2_src[0];
         au2_flt[4 * nt] = pu2_src[4 * nt];
 
@@ -613,7 +612,7 @@ void ihevc_hbd_intra_pred_ref_filtering(UWORD16 *pu2_src,
         }
 
         for(i = 0; i < (four_nt + 1); i++)
-             pu2_dst[i] = au2_flt[i];
+            pu2_dst[i] = au2_flt[i];
     }
 }
 
@@ -813,7 +812,7 @@ void ihevc_hbd_intra_pred_luma_dc(UWORD16 *pu2_ref,
             pu2_dst[row * dst_strd] = (pu2_ref[two_nt - 1 - row] + three_dc_val + 2)
                             >> 2;
 
-        /* Fill the remaining rows with DC value*/
+        /* Fill the remaining rows with DC value */
         for(row = 1; row < nt; row++)
             for(col = 1; col < nt; col++)
                 pu2_dst[(row * dst_strd) + col] = dc_val;
@@ -885,7 +884,7 @@ void ihevc_hbd_intra_pred_luma_horz(UWORD16 *pu2_ref,
     }
     else
     {
-        /*Filtering done for the 1st row */
+        /* Filtering done for the 1st row */
         for(col = 0; col < nt; col++)
         {
             s2_predpixel = pu2_ref[two_nt - 1]
@@ -895,7 +894,7 @@ void ihevc_hbd_intra_pred_luma_horz(UWORD16 *pu2_ref,
 
         }
 
-        /* Replication to next rows*/
+        /* Replication to next rows */
         for(row = 1; row < nt; row++)
             for(col = 0; col < nt; col++)
                 pu2_dst[(row * dst_strd) + col] = pu2_ref[two_nt - 1 - row];
@@ -955,14 +954,14 @@ void ihevc_hbd_intra_pred_luma_ver(UWORD16 *pu2_ref,
 
     if(nt == 32 || disable_boundary_filter)
     {
-        /* Replication to next columns*/
+        /* Replication to next columns */
         for(row = 0; row < nt; row++)
             for(col = 0; col < nt; col++)
                 pu2_dst[(row * dst_strd) + col] = pu2_ref[two_nt + 1 + col];
     }
     else
     {
-        /*Filtering done for the 1st column */
+        /* Filtering done for the 1st column */
         for(row = 0; row < nt; row++)
         {
             s2_predpixel = pu2_ref[two_nt + 1]
@@ -971,7 +970,7 @@ void ihevc_hbd_intra_pred_luma_ver(UWORD16 *pu2_ref,
             pu2_dst[row * dst_strd] = CLIP3(s2_predpixel,0,((1<<bit_depth)-1));
         }
 
-        /* Replication to next columns*/
+        /* Replication to next columns */
         for(row = 0; row < nt; row++)
             for(col = 1; col < nt; col++)
                 pu2_dst[(row * dst_strd) + col] = pu2_ref[two_nt + 1 + col];
@@ -1093,7 +1092,7 @@ void ihevc_hbd_intra_pred_luma_mode_18_34(UWORD16 *pu2_ref,
     WORD32 idx = 0;
     WORD32 two_nt = 2 * nt;
 
-    intra_pred_ang = 32;    /*Default value*/
+    intra_pred_ang = 32;    /* Default value */
 
     /* For mode 18, angle is -45degree */
     if(mode == 18)
@@ -1102,7 +1101,7 @@ void ihevc_hbd_intra_pred_luma_mode_18_34(UWORD16 *pu2_ref,
     else if(mode == 34)
         intra_pred_ang = 32;
     /* For the angle 45 and -45, replication is done from the corresponding angle */
-    /* No interpolation is done for 45 degree*/
+    /* No interpolation is done for 45 degree */
     for(row = 0; row < nt; row++)
     {
         idx = ((row + 1) * intra_pred_ang) >> 5;
@@ -1243,9 +1242,9 @@ void ihevc_hbd_intra_pred_luma_mode_11_to_17(UWORD16 *pu2_ref,
                                              WORD32 mode,
                                              UWORD8 bit_depth)
 {
-    /* This function and ihevc_intra_pred_luma_mode_19_to_25 are same except*/
+    /* This function and ihevc_intra_pred_luma_mode_19_to_25 are same except */
     /* for ref main & side samples assignment,can be combined for */
-    /* optimzation*/
+    /* optimzation */
 
     WORD32 row, col, k;
     WORD32 two_nt;
@@ -1263,7 +1262,7 @@ void ihevc_hbd_intra_pred_luma_mode_11_to_17(UWORD16 *pu2_ref,
 
     inv_ang = gai4_ihevc_inv_ang_table[mode - 11];
     /* Intermediate reference samples for negative angle modes */
-    /* This have to be removed during optimization*/
+    /* This have to be removed during optimization */
     /* For horizontal modes, (ref main = ref left) (ref side = ref above) */
 
     ref_main = ref_temp + nt - 1;
@@ -1363,7 +1362,7 @@ void ihevc_hbd_intra_pred_luma_mode_19_to_25(UWORD16 *pu2_ref,
     inv_ang = gai4_ihevc_inv_ang_table[mode - 12];
 
     /* Intermediate reference samples for negative angle modes */
-    /* This have to be removed during optimization*/
+    /* This have to be removed during optimization */
     /* For horizontal modes, (ref main = ref above) (ref side = ref left) */
     ref_main = ref_temp + nt - 1;
     for(k = 0; k < (nt + 1); k++)

--- a/common/ihevc_hbd_iquant_recon.c
+++ b/common/ihevc_hbd_iquant_recon.c
@@ -76,22 +76,22 @@
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -105,12 +105,12 @@ void ihevc_hbd_iquant_recon_4x4_ttype1(WORD16 *pi2_src,
                                        UWORD16 *pu2_pred,
                                        WORD16 *pi2_dequant_coeff,
                                        UWORD16 *pu2_dst,
-                                       WORD32 i4_qp_div, /* qpscaled / 6 */
-                                       WORD32 i4_qp_rem, /* qpscaled % 6 */
-                                       WORD32 i4_src_strd,
-                                       WORD32 i4_pred_strd,
-                                       WORD32 i4_dst_strd,
-                                       WORD32 i4_zero_cols,
+                                       WORD32 qp_div, /* qpscaled / 6 */
+                                       WORD32 qp_rem, /* qpscaled % 6 */
+                                       WORD32 src_strd,
+                                       WORD32 pred_strd,
+                                       WORD32 dst_strd,
+                                       WORD32 zero_cols,
                                        UWORD8 u1_bit_depth)
 {
     /* Inverse Quant and recon */
@@ -118,7 +118,7 @@ void ihevc_hbd_iquant_recon_4x4_ttype1(WORD16 *pi2_src,
     WORD32 shift_iq;
     WORD32 trans_size;
     WORD16 clip_limit;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     /* Inverse Quantization constants */
     {
         WORD32 log2_trans_size;
@@ -128,31 +128,31 @@ void ihevc_hbd_iquant_recon_4x4_ttype1(WORD16 *pi2_src,
     }
 
     trans_size = TRANS_SIZE_4;
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT_4x4(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
 
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3(( iquant_out + pu2_pred[j*i4_pred_strd] ), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3(( iquant_out + pu2_pred[j*pred_strd] ), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -160,7 +160,7 @@ void ihevc_hbd_iquant_recon_4x4_ttype1(WORD16 *pi2_src,
         pu2_pred++;
         pu2_dst++;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -186,22 +186,22 @@ void ihevc_hbd_iquant_recon_4x4_ttype1(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -215,12 +215,12 @@ void ihevc_hbd_iquant_recon_4x4(WORD16 *pi2_src,
                                 UWORD16 *pu2_pred,
                                 WORD16 *pi2_dequant_coeff,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_qp_div, /* qpscaled / 6 */
-                                WORD32 i4_qp_rem, /* qpscaled % 6 */
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
+                                WORD32 qp_div, /* qpscaled / 6 */
+                                WORD32 qp_rem, /* qpscaled % 6 */
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
                                 UWORD8 u1_bit_depth)
 {
     /* Inverse Quant and recon */
@@ -228,7 +228,7 @@ void ihevc_hbd_iquant_recon_4x4(WORD16 *pi2_src,
     WORD32 shift_iq;
     WORD32 trans_size;
     WORD16 clip_limit;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     /* Inverse Quantization constants */
     {
         WORD32 log2_trans_size;
@@ -238,30 +238,30 @@ void ihevc_hbd_iquant_recon_4x4(WORD16 *pi2_src,
     }
 
     trans_size = TRANS_SIZE_4;
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT_4x4(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3(( iquant_out + pu2_pred[j*i4_pred_strd] ), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3(( iquant_out + pu2_pred[j*pred_strd] ), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -269,7 +269,7 @@ void ihevc_hbd_iquant_recon_4x4(WORD16 *pi2_src,
         pu2_pred++;
         pu2_dst++;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -295,22 +295,22 @@ void ihevc_hbd_iquant_recon_4x4(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 8x8 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -324,12 +324,12 @@ void ihevc_hbd_iquant_recon_8x8(WORD16 *pi2_src,
                                 UWORD16 *pu2_pred,
                                 WORD16 *pi2_dequant_coeff,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_qp_div, /* qpscaled / 6 */
-                                WORD32 i4_qp_rem, /* qpscaled % 6 */
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
+                                WORD32 qp_div, /* qpscaled / 6 */
+                                WORD32 qp_rem, /* qpscaled % 6 */
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
                                 UWORD8 u1_bit_depth)
 {
     /* Inverse Quant and recon */
@@ -337,7 +337,7 @@ void ihevc_hbd_iquant_recon_8x8(WORD16 *pi2_src,
     WORD32 shift_iq;
     WORD32 trans_size;
     WORD16 clip_limit;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     /* Inverse Quantization constants */
     {
         WORD32 log2_trans_size;
@@ -347,31 +347,31 @@ void ihevc_hbd_iquant_recon_8x8(WORD16 *pi2_src,
     }
 
     trans_size = TRANS_SIZE_8;
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
 
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3(( iquant_out + pu2_pred[j*i4_pred_strd] ), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3(( iquant_out + pu2_pred[j*pred_strd] ), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -379,7 +379,7 @@ void ihevc_hbd_iquant_recon_8x8(WORD16 *pi2_src,
         pu2_pred++;
         pu2_dst++;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -405,22 +405,22 @@ void ihevc_hbd_iquant_recon_8x8(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 16x16 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -434,12 +434,12 @@ void ihevc_hbd_iquant_recon_16x16(WORD16 *pi2_src,
                                   UWORD16 *pu2_pred,
                                   WORD16 *pi2_dequant_coeff,
                                   UWORD16 *pu2_dst,
-                                  WORD32 i4_qp_div, /* qpscaled / 6 */
-                                  WORD32 i4_qp_rem, /* qpscaled % 6 */
-                                  WORD32 i4_src_strd,
-                                  WORD32 i4_pred_strd,
-                                  WORD32 i4_dst_strd,
-                                  WORD32 i4_zero_cols,
+                                  WORD32 qp_div, /* qpscaled / 6 */
+                                  WORD32 qp_rem, /* qpscaled % 6 */
+                                  WORD32 src_strd,
+                                  WORD32 pred_strd,
+                                  WORD32 dst_strd,
+                                  WORD32 zero_cols,
                                   UWORD8 u1_bit_depth)
 
 {
@@ -448,7 +448,7 @@ void ihevc_hbd_iquant_recon_16x16(WORD16 *pi2_src,
     WORD32 shift_iq;
     WORD32 trans_size;
     WORD16 clip_limit;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     /* Inverse Quantization constants */
     {
         WORD32 log2_trans_size;
@@ -458,30 +458,30 @@ void ihevc_hbd_iquant_recon_16x16(WORD16 *pi2_src,
     }
 
     trans_size = TRANS_SIZE_16;
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size] * g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size] * g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3(( iquant_out + pu2_pred[j*i4_pred_strd] ), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3(( iquant_out + pu2_pred[j*pred_strd] ), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -489,7 +489,7 @@ void ihevc_hbd_iquant_recon_16x16(WORD16 *pi2_src,
         pu2_pred++;
         pu2_dst++;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -515,22 +515,22 @@ void ihevc_hbd_iquant_recon_16x16(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 32x32 block
  *
- * @param[in] i4_qp_div
+ * @param[in] qp_div
  *  Quantization parameter / 6
  *
- * @param[in] i4_qp_rem
+ * @param[in] qp_rem
  *  Quantization parameter % 6
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -544,12 +544,12 @@ void ihevc_hbd_iquant_recon_32x32(WORD16 *pi2_src,
                                   UWORD16 *pu2_pred,
                                   WORD16 *pi2_dequant_coeff,
                                   UWORD16 *pu2_dst,
-                                  WORD32 i4_qp_div, /* qpscaled / 6 */
-                                  WORD32 i4_qp_rem, /* qpscaled % 6 */
-                                  WORD32 i4_src_strd,
-                                  WORD32 i4_pred_strd,
-                                  WORD32 i4_dst_strd,
-                                  WORD32 i4_zero_cols,
+                                  WORD32 qp_div, /* qpscaled / 6 */
+                                  WORD32 qp_rem, /* qpscaled % 6 */
+                                  WORD32 src_strd,
+                                  WORD32 pred_strd,
+                                  WORD32 dst_strd,
+                                  WORD32 zero_cols,
                                   UWORD8 u1_bit_depth)
 {
     /* Inverse Quant and recon */
@@ -557,7 +557,7 @@ void ihevc_hbd_iquant_recon_32x32(WORD16 *pi2_src,
     WORD32 shift_iq;
     WORD32 trans_size;
     WORD16 clip_limit;
-    WORD32 shift_skip_trans,add_skip_trans;
+    WORD32 shift_skip_trans, add_skip_trans;
     /* Inverse Quantization constants */
     {
         WORD32 log2_trans_size;
@@ -567,31 +567,31 @@ void ihevc_hbd_iquant_recon_32x32(WORD16 *pi2_src,
     }
 
     trans_size = TRANS_SIZE_32;
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
         }
         else
         {
             shift_skip_trans = 13 - u1_bit_depth;
-            add_skip_trans = (1 << (shift_skip_trans -1));
+            add_skip_trans = (1 << (shift_skip_trans - 1));
 
             for(j = 0; j < trans_size; j++)
             {
                 WORD32 iquant_out;
                 IQUANT(iquant_out,
-                    pi2_src[j*i4_src_strd],
-                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[i4_qp_rem],
-                    shift_iq, i4_qp_div);
+                    pi2_src[j*src_strd],
+                    pi2_dequant_coeff[j*trans_size]* g_ihevc_iquant_scales[qp_rem],
+                    shift_iq, qp_div);
                 iquant_out = (iquant_out + add_skip_trans) >> shift_skip_trans;
-                pu2_dst[j * i4_dst_strd] =
-                    CLIP3(( iquant_out + pu2_pred[j*i4_pred_strd] ), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                    CLIP3(( iquant_out + pu2_pred[j*pred_strd] ), 0, clip_limit);
             }
         }
         pi2_src++;
@@ -599,6 +599,6 @@ void ihevc_hbd_iquant_recon_32x32(WORD16 *pi2_src,
         pu2_pred++;
         pu2_dst++;
 
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }

--- a/common/ihevc_hbd_itrans_recon.c
+++ b/common/ihevc_hbd_itrans_recon.c
@@ -79,16 +79,16 @@
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -102,11 +102,11 @@ void ihevc_hbd_itrans_recon_4x4_ttype1(WORD16 *pi2_src,
                                        WORD16 *pi2_tmp,
                                        UWORD16 *pu2_pred,
                                        UWORD16 *pu2_dst,
-                                       WORD32 i4_src_strd,
-                                       WORD32 i4_pred_strd,
-                                       WORD32 i4_dst_strd,
-                                       WORD32 i4_zero_cols,
-                                       WORD32 i4_zero_rows,
+                                       WORD32 src_strd,
+                                       WORD32 pred_strd,
+                                       WORD32 dst_strd,
+                                       WORD32 zero_cols,
+                                       WORD32 zero_rows,
                                        UWORD8 u1_bit_depth)
 {
     WORD32 i, c[4];
@@ -127,30 +127,30 @@ void ihevc_hbd_itrans_recon_4x4_ttype1(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
         }
         else
         {
             // Intermediate Variables
-            c[0] = pi2_src[0] + pi2_src[2 * i4_src_strd];
-            c[1] = pi2_src[2 * i4_src_strd] + pi2_src[3 * i4_src_strd];
-            c[2] = pi2_src[0] - pi2_src[3 * i4_src_strd];
-            c[3] = 74 * pi2_src[i4_src_strd];
+            c[0] = pi2_src[0] + pi2_src[2 * src_strd];
+            c[1] = pi2_src[2 * src_strd] + pi2_src[3 * src_strd];
+            c[2] = pi2_src[0] - pi2_src[3 * src_strd];
+            c[3] = 74 * pi2_src[src_strd];
 
             pi2_tmp[0] =
                             CLIP_S16(( 29 * c[0] + 55 * c[1] + c[3] + add ) >> shift );
             pi2_tmp[1] =
                             CLIP_S16(( 55 * c[2] - 29 * c[1] + c[3] + add ) >> shift );
             pi2_tmp[2] =
-                            CLIP_S16(( 74 * (pi2_src[0] - pi2_src[2 * i4_src_strd ] + pi2_src[3 * i4_src_strd ]) + add ) >> shift );
+                            CLIP_S16(( 74 * (pi2_src[0] - pi2_src[2 * src_strd ] + pi2_src[3 * src_strd ]) + add ) >> shift );
             pi2_tmp[3] =
                             CLIP_S16(( 55 * c[0] + 29 * c[2] - c[3] + add ) >> shift );
         }
         pi2_src++;
         pi2_tmp += trans_size;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 
     pi2_tmp = pi2_tmp_orig;
@@ -158,7 +158,7 @@ void ihevc_hbd_itrans_recon_4x4_ttype1(WORD16 *pi2_src,
     /* Inverse Transform 2nd stage */
     shift = 20 - u1_bit_depth;
     add = 1 << (shift - 1);
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(i = 0; i < trans_size; i++)
     {
@@ -182,8 +182,8 @@ void ihevc_hbd_itrans_recon_4x4_ttype1(WORD16 *pi2_src,
                         CLIP_S16(( 55 * c[0] + 29 * c[2] - c[3] + add ) >> shift );
         pu2_dst[3] = CLIP3( (itrans_out+ pu2_pred[3] ), 0, clip_limit );
         pi2_tmp++;
-        pu2_pred += i4_pred_strd;
-        pu2_dst += i4_dst_strd;
+        pu2_pred += pred_strd;
+        pu2_dst += dst_strd;
     }
 }
 /**
@@ -212,19 +212,19 @@ void ihevc_hbd_itrans_recon_4x4_ttype1(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -238,11 +238,11 @@ void ihevc_hbd_itrans_recon_4x4(WORD16 *pi2_src,
                                 WORD16 *pi2_tmp,
                                 UWORD16 *pu2_pred,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
-                                WORD32 i4_zero_rows,
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
+                                WORD32 zero_rows,
                                 UWORD8 u1_bit_depth)
 
 {
@@ -265,21 +265,21 @@ void ihevc_hbd_itrans_recon_4x4(WORD16 *pi2_src,
     for(j = 0; j < trans_size; j++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
         }
         else
         {
             /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
-            o[0] = g_ai2_ihevc_trans_4[1][0] * pi2_src[i4_src_strd]
-                            + g_ai2_ihevc_trans_4[3][0] * pi2_src[3 * i4_src_strd];
-            o[1] = g_ai2_ihevc_trans_4[1][1] * pi2_src[i4_src_strd]
-                            + g_ai2_ihevc_trans_4[3][1] * pi2_src[3 * i4_src_strd];
+            o[0] = g_ai2_ihevc_trans_4[1][0] * pi2_src[src_strd]
+                            + g_ai2_ihevc_trans_4[3][0] * pi2_src[3 * src_strd];
+            o[1] = g_ai2_ihevc_trans_4[1][1] * pi2_src[src_strd]
+                            + g_ai2_ihevc_trans_4[3][1] * pi2_src[3 * src_strd];
             e[0] = g_ai2_ihevc_trans_4[0][0] * pi2_src[0]
-                            + g_ai2_ihevc_trans_4[2][0] * pi2_src[2 * i4_src_strd];
+                            + g_ai2_ihevc_trans_4[2][0] * pi2_src[2 * src_strd];
             e[1] = g_ai2_ihevc_trans_4[0][1] * pi2_src[0]
-                            + g_ai2_ihevc_trans_4[2][1] * pi2_src[2 * i4_src_strd];
+                            + g_ai2_ihevc_trans_4[2][1] * pi2_src[2 * src_strd];
 
             pi2_tmp[0] =
                             CLIP_S16( ((e[0] + o[0] + add)>>shift) );
@@ -292,7 +292,7 @@ void ihevc_hbd_itrans_recon_4x4(WORD16 *pi2_src,
         }
         pi2_src++;
         pi2_tmp += trans_size;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 
     pi2_tmp = pi2_tmp_orig;
@@ -300,7 +300,7 @@ void ihevc_hbd_itrans_recon_4x4(WORD16 *pi2_src,
     /* Inverse Transform 2nd stage */
     shift = 20 - u1_bit_depth;
     add = 1 << (shift - 1);
-    clip_limit = (1 << u1_bit_depth) -1;
+    clip_limit = (1 << u1_bit_depth) - 1;
 
     for(j = 0; j < trans_size; j++)
     {
@@ -329,7 +329,7 @@ void ihevc_hbd_itrans_recon_4x4(WORD16 *pi2_src,
         pu2_dst[3] = CLIP3( (itrans_out + pu2_pred[3] ), 0, clip_limit );
 
         pi2_tmp++;
-        pu2_pred += i4_pred_strd;
-        pu2_dst += i4_dst_strd;
+        pu2_pred += pred_strd;
+        pu2_dst += dst_strd;
     }
 }

--- a/common/ihevc_hbd_itrans_recon_16x16.c
+++ b/common/ihevc_hbd_itrans_recon_16x16.c
@@ -72,19 +72,19 @@
  * @param[out] pu2_dst
  *  Output 16x16 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -98,11 +98,11 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                                   WORD16 *pi2_tmp,
                                   UWORD16 *pu2_pred,
                                   UWORD16 *pu2_dst,
-                                  WORD32 i4_src_strd,
-                                  WORD32 i4_pred_strd,
-                                  WORD32 i4_dst_strd,
-                                  WORD32 i4_zero_cols,
-                                  WORD32 i4_zero_rows,
+                                  WORD32 src_strd,
+                                  WORD32 pred_strd,
+                                  WORD32 dst_strd,
+                                  WORD32 zero_cols,
+                                  WORD32 zero_rows,
                                   UWORD8 u1_bit_depth)
 {
     WORD32 j, k;
@@ -113,13 +113,13 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
     WORD32 shift;
     WORD16 *pi2_tmp_orig;
     WORD32 trans_size;
-    WORD32 zero_rows_2nd_stage = i4_zero_cols;
+    WORD32 zero_rows_2nd_stage = zero_cols;
     WORD32 row_limit_2nd_stage;
     WORD16 clip_limit;
 
-    if((i4_zero_cols & 0xFFF0) == 0xFFF0)
+    if((zero_cols & 0xFFF0) == 0xFFF0)
         row_limit_2nd_stage = 4;
-    else if((i4_zero_cols & 0xFF00) == 0xFF00)
+    else if((zero_cols & 0xFF00) == 0xFF00)
         row_limit_2nd_stage = 8;
     else
         row_limit_2nd_stage = TRANS_SIZE_16;
@@ -128,7 +128,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
     pi2_tmp_orig = pi2_tmp;
     clip_limit = (1 << u1_bit_depth) - 1;
 
-    if((i4_zero_rows & 0xFFF0) == 0xFFF0)  /* First 4 rows of input are non-zero */
+    if((zero_rows & 0xFFF0) == 0xFFF0)  /* First 4 rows of input are non-zero */
     {
         /* Inverse Transform 1st stage */
         /************************************************************************************************/
@@ -141,7 +141,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -150,13 +150,13 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 8; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_16[3][k]
-                                                    * pi2_src[3 * i4_src_strd];
+                                                    * pi2_src[3 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * i4_src_strd];
+                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * src_strd];
                 }
                 eeo[0] = 0;
                 eee[0] = g_ai2_ihevc_trans_16[0][0] * pi2_src[0];
@@ -184,7 +184,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -235,8 +235,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFF00) == 0xFF00) /* First 4 rows of output of 1st stage are non-zero */
@@ -287,8 +287,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -361,15 +361,15 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
         /************************************END - IT_RECON_16x16****************************************/
         /************************************************************************************************/
     }
-    else if((i4_zero_rows & 0xFF00) == 0xFF00)  /* First 8 rows of input are non-zero */
+    else if((zero_rows & 0xFF00) == 0xFF00)  /* First 8 rows of input are non-zero */
     {
         /* Inverse Transform 1st stage */
         /************************************************************************************************/
@@ -382,7 +382,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -391,23 +391,23 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 8; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_16[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_16[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_16[7][k]
-                                                    * pi2_src[7 * i4_src_strd];
+                                                    * pi2_src[7 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * src_strd]
                                     + g_ai2_ihevc_trans_16[6][k]
-                                                    * pi2_src[6 * i4_src_strd];
+                                                    * pi2_src[6 * src_strd];
                 }
-                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * i4_src_strd];
+                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * src_strd];
                 eee[0] = g_ai2_ihevc_trans_16[0][0] * pi2_src[0];
-                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * i4_src_strd];
+                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * src_strd];
                 eee[1] = g_ai2_ihevc_trans_16[0][1] * pi2_src[0];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
@@ -431,7 +431,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -482,8 +482,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFF00) == 0xFF00) /* First 4 rows of output of 1st stage are non-zero */
@@ -534,8 +534,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -608,8 +608,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
@@ -629,7 +629,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -638,48 +638,48 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 8; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_16[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_16[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_16[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_16[7][k]
-                                                    * pi2_src[7 * i4_src_strd]
+                                                    * pi2_src[7 * src_strd]
                                     + g_ai2_ihevc_trans_16[9][k]
-                                                    * pi2_src[9 * i4_src_strd]
+                                                    * pi2_src[9 * src_strd]
                                     + g_ai2_ihevc_trans_16[11][k]
-                                                    * pi2_src[11 * i4_src_strd]
+                                                    * pi2_src[11 * src_strd]
                                     + g_ai2_ihevc_trans_16[13][k]
-                                                    * pi2_src[13 * i4_src_strd]
+                                                    * pi2_src[13 * src_strd]
                                     + g_ai2_ihevc_trans_16[15][k]
-                                                    * pi2_src[15 * i4_src_strd];
+                                                    * pi2_src[15 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_16[2][k] * pi2_src[2 * src_strd]
                                     + g_ai2_ihevc_trans_16[6][k]
-                                                    * pi2_src[6 * i4_src_strd]
+                                                    * pi2_src[6 * src_strd]
                                     + g_ai2_ihevc_trans_16[10][k]
-                                                    * pi2_src[10 * i4_src_strd]
+                                                    * pi2_src[10 * src_strd]
                                     + g_ai2_ihevc_trans_16[14][k]
-                                                    * pi2_src[14 * i4_src_strd];
+                                                    * pi2_src[14 * src_strd];
                 }
-                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * i4_src_strd]
+                eeo[0] = g_ai2_ihevc_trans_16[4][0] * pi2_src[4 * src_strd]
                                 + g_ai2_ihevc_trans_16[12][0]
-                                                * pi2_src[12 * i4_src_strd];
+                                                * pi2_src[12 * src_strd];
                 eee[0] =
                                 g_ai2_ihevc_trans_16[0][0] * pi2_src[0]
                                                 + g_ai2_ihevc_trans_16[8][0]
                                                                 * pi2_src[8
-                                                                                * i4_src_strd];
-                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * i4_src_strd]
+                                                                                * src_strd];
+                eeo[1] = g_ai2_ihevc_trans_16[4][1] * pi2_src[4 * src_strd]
                                 + g_ai2_ihevc_trans_16[12][1]
-                                                * pi2_src[12 * i4_src_strd];
+                                                * pi2_src[12 * src_strd];
                 eee[1] =
                                 g_ai2_ihevc_trans_16[0][1] * pi2_src[0]
                                                 + g_ai2_ihevc_trans_16[8][1]
                                                                 * pi2_src[8
-                                                                                * i4_src_strd];
+                                                                                * src_strd];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
                 for(k = 0; k < 2; k++)
@@ -702,7 +702,7 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -753,8 +753,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFF00) == 0xFF00) /* First 4 rows of output of 1st stage are non-zero */
@@ -805,8 +805,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -879,8 +879,8 @@ void ihevc_hbd_itrans_recon_16x16(WORD16 *pi2_src,
                     pu2_dst[k + 8] = CLIP3((itrans_out + pu2_pred[k+8]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/

--- a/common/ihevc_hbd_itrans_recon_32x32.c
+++ b/common/ihevc_hbd_itrans_recon_32x32.c
@@ -73,19 +73,19 @@
  * @param[out] pu2_dst
  *  Output 32x32 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -99,11 +99,11 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                                   WORD16 *pi2_tmp,
                                   UWORD16 *pu2_pred,
                                   UWORD16 *pu2_dst,
-                                  WORD32 i4_src_strd,
-                                  WORD32 i4_pred_strd,
-                                  WORD32 i4_dst_strd,
-                                  WORD32 i4_zero_cols,
-                                  WORD32 i4_zero_rows,
+                                  WORD32 src_strd,
+                                  WORD32 pred_strd,
+                                  WORD32 dst_strd,
+                                  WORD32 zero_cols,
+                                  WORD32 zero_rows,
                                   UWORD8 u1_bit_depth)
 {
     WORD32 j, k;
@@ -115,7 +115,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
     WORD32 shift;
     WORD16 *pi2_tmp_orig;
     WORD32 trans_size;
-    WORD32 zero_rows_2nd_stage = i4_zero_cols;
+    WORD32 zero_rows_2nd_stage = zero_cols;
     WORD32 row_limit_2nd_stage;
     WORD16 clip_limit;
 
@@ -123,14 +123,14 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
     pi2_tmp_orig = pi2_tmp;
     clip_limit = (1 << u1_bit_depth) - 1;
 
-    if((i4_zero_cols & 0xFFFFFFF0) == 0xFFFFFFF0)
+    if((zero_cols & 0xFFFFFFF0) == 0xFFFFFFF0)
         row_limit_2nd_stage = 4;
-    else if((i4_zero_cols & 0xFFFFFF00) == 0xFFFFFF00)
+    else if((zero_cols & 0xFFFFFF00) == 0xFFFFFF00)
         row_limit_2nd_stage = 8;
     else
         row_limit_2nd_stage = TRANS_SIZE_32;
 
-    if((i4_zero_rows & 0xFFFFFFF0) == 0xFFFFFFF0)  /* First 4 rows of input are non-zero */
+    if((zero_rows & 0xFFFFFFF0) == 0xFFFFFFF0)  /* First 4 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_32x32****************************************/
@@ -142,7 +142,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -151,13 +151,13 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 16; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_32[3][k]
-                                                    * pi2_src[3 * i4_src_strd];
+                                                    * pi2_src[3 * src_strd];
                 }
                 for(k = 0; k < 8; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * i4_src_strd];
+                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * src_strd];
                 }
                 {
                     eeo[0] = 0;
@@ -195,7 +195,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -255,8 +255,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -315,8 +315,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -433,15 +433,15 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
         /************************************END - IT_RECON_32x32****************************************/
         /************************************************************************************************/
     }
-    else if((i4_zero_rows & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of input are non-zero */
+    else if((zero_rows & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_32x32****************************************/
@@ -453,7 +453,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -462,23 +462,23 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 16; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_32[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_32[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_32[7][k]
-                                                    * pi2_src[7 * i4_src_strd];
+                                                    * pi2_src[7 * src_strd];
                 }
                 for(k = 0; k < 8; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * src_strd]
                                     + g_ai2_ihevc_trans_32[6][k]
-                                                    * pi2_src[6 * i4_src_strd];
+                                                    * pi2_src[6 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * i4_src_strd];
+                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * src_strd];
                 }
                 eeeo[0] = 0;
                 eeeo[1] = 0;
@@ -510,7 +510,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -570,8 +570,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -630,8 +630,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -748,8 +748,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
@@ -768,7 +768,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -777,78 +777,78 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 16; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_32[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_32[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_32[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_32[7][k]
-                                                    * pi2_src[7 * i4_src_strd]
+                                                    * pi2_src[7 * src_strd]
                                     + g_ai2_ihevc_trans_32[9][k]
-                                                    * pi2_src[9 * i4_src_strd]
+                                                    * pi2_src[9 * src_strd]
                                     + g_ai2_ihevc_trans_32[11][k]
-                                                    * pi2_src[11 * i4_src_strd]
+                                                    * pi2_src[11 * src_strd]
                                     + g_ai2_ihevc_trans_32[13][k]
-                                                    * pi2_src[13 * i4_src_strd]
+                                                    * pi2_src[13 * src_strd]
                                     + g_ai2_ihevc_trans_32[15][k]
-                                                    * pi2_src[15 * i4_src_strd]
+                                                    * pi2_src[15 * src_strd]
                                     + g_ai2_ihevc_trans_32[17][k]
-                                                    * pi2_src[17 * i4_src_strd]
+                                                    * pi2_src[17 * src_strd]
                                     + g_ai2_ihevc_trans_32[19][k]
-                                                    * pi2_src[19 * i4_src_strd]
+                                                    * pi2_src[19 * src_strd]
                                     + g_ai2_ihevc_trans_32[21][k]
-                                                    * pi2_src[21 * i4_src_strd]
+                                                    * pi2_src[21 * src_strd]
                                     + g_ai2_ihevc_trans_32[23][k]
-                                                    * pi2_src[23 * i4_src_strd]
+                                                    * pi2_src[23 * src_strd]
                                     + g_ai2_ihevc_trans_32[25][k]
-                                                    * pi2_src[25 * i4_src_strd]
+                                                    * pi2_src[25 * src_strd]
                                     + g_ai2_ihevc_trans_32[27][k]
-                                                    * pi2_src[27 * i4_src_strd]
+                                                    * pi2_src[27 * src_strd]
                                     + g_ai2_ihevc_trans_32[29][k]
-                                                    * pi2_src[29 * i4_src_strd]
+                                                    * pi2_src[29 * src_strd]
                                     + g_ai2_ihevc_trans_32[31][k]
-                                                    * pi2_src[31 * i4_src_strd];
+                                                    * pi2_src[31 * src_strd];
                 }
                 for(k = 0; k < 8; k++)
                 {
-                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * i4_src_strd]
+                    eo[k] = g_ai2_ihevc_trans_32[2][k] * pi2_src[2 * src_strd]
                                     + g_ai2_ihevc_trans_32[6][k]
-                                                    * pi2_src[6 * i4_src_strd]
+                                                    * pi2_src[6 * src_strd]
                                     + g_ai2_ihevc_trans_32[10][k]
-                                                    * pi2_src[10 * i4_src_strd]
+                                                    * pi2_src[10 * src_strd]
                                     + g_ai2_ihevc_trans_32[14][k]
-                                                    * pi2_src[14 * i4_src_strd]
+                                                    * pi2_src[14 * src_strd]
                                     + g_ai2_ihevc_trans_32[18][k]
-                                                    * pi2_src[18 * i4_src_strd]
+                                                    * pi2_src[18 * src_strd]
                                     + g_ai2_ihevc_trans_32[22][k]
-                                                    * pi2_src[22 * i4_src_strd]
+                                                    * pi2_src[22 * src_strd]
                                     + g_ai2_ihevc_trans_32[26][k]
-                                                    * pi2_src[26 * i4_src_strd]
+                                                    * pi2_src[26 * src_strd]
                                     + g_ai2_ihevc_trans_32[30][k]
-                                                    * pi2_src[30 * i4_src_strd];
+                                                    * pi2_src[30 * src_strd];
                 }
                 for(k = 0; k < 4; k++)
                 {
-                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * i4_src_strd]
+                    eeo[k] = g_ai2_ihevc_trans_32[4][k] * pi2_src[4 * src_strd]
                                     + g_ai2_ihevc_trans_32[12][k]
-                                                    * pi2_src[12 * i4_src_strd]
+                                                    * pi2_src[12 * src_strd]
                                     + g_ai2_ihevc_trans_32[20][k]
-                                                    * pi2_src[20 * i4_src_strd]
+                                                    * pi2_src[20 * src_strd]
                                     + g_ai2_ihevc_trans_32[28][k]
-                                                    * pi2_src[28 * i4_src_strd];
+                                                    * pi2_src[28 * src_strd];
                 }
-                eeeo[0] = g_ai2_ihevc_trans_32[8][0] * pi2_src[8 * i4_src_strd]
+                eeeo[0] = g_ai2_ihevc_trans_32[8][0] * pi2_src[8 * src_strd]
                                 + g_ai2_ihevc_trans_32[24][0]
-                                                * pi2_src[24 * i4_src_strd];
-                eeeo[1] = g_ai2_ihevc_trans_32[8][1] * pi2_src[8 * i4_src_strd]
+                                                * pi2_src[24 * src_strd];
+                eeeo[1] = g_ai2_ihevc_trans_32[8][1] * pi2_src[8 * src_strd]
                                 + g_ai2_ihevc_trans_32[24][1]
-                                                * pi2_src[24 * i4_src_strd];
+                                                * pi2_src[24 * src_strd];
                 eeee[0] = g_ai2_ihevc_trans_32[0][0] * pi2_src[0]
                                 + g_ai2_ihevc_trans_32[16][0]
-                                                * pi2_src[16 * i4_src_strd];
+                                                * pi2_src[16 * src_strd];
                 eeee[1] = g_ai2_ihevc_trans_32[0][1] * pi2_src[0]
                                 + g_ai2_ihevc_trans_32[16][1]
-                                                * pi2_src[16 * i4_src_strd];
+                                                * pi2_src[16 * src_strd];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
                 eee[0] = eeee[0] + eeeo[0];
@@ -875,7 +875,7 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -935,8 +935,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else if((zero_rows_2nd_stage & 0xFFFFFF00) == 0xFFFFFF00) /* First 8 rows of output of 1st stage are non-zero */
@@ -995,8 +995,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -1113,8 +1113,8 @@ void ihevc_hbd_itrans_recon_32x32(WORD16 *pi2_src,
                     pu2_dst[k + 16] = CLIP3((itrans_out + pu2_pred[k+16]), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/

--- a/common/ihevc_hbd_itrans_recon_8x8.c
+++ b/common/ihevc_hbd_itrans_recon_8x8.c
@@ -72,19 +72,19 @@
  * @param[out] pu2_dst
  *  Output 8x8 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_src
  *
  * @returns  Void
@@ -98,11 +98,11 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                                 WORD16 *pi2_tmp,
                                 UWORD16 *pu2_pred,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
-                                WORD32 i4_zero_rows,
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
+                                WORD32 zero_rows,
                                 UWORD8 u1_bit_depth)
 {
     WORD32 j, k;
@@ -112,7 +112,7 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
     WORD32 shift;
     WORD16 *pi2_tmp_orig;
     WORD32 trans_size;
-    WORD32 zero_rows_2nd_stage = i4_zero_cols;
+    WORD32 zero_rows_2nd_stage = zero_cols;
     WORD32 row_limit_2nd_stage;
     WORD16 clip_limit;
 
@@ -121,13 +121,13 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
 
     pi2_tmp_orig = pi2_tmp;
 
-    if((i4_zero_cols & 0xF0) == 0xF0)
+    if((zero_cols & 0xF0) == 0xF0)
         row_limit_2nd_stage = 4;
     else
         row_limit_2nd_stage = TRANS_SIZE_8;
 
 
-    if((i4_zero_rows & 0xF0) == 0xF0) /* First 4 rows of input are non-zero */
+    if((zero_rows & 0xF0) == 0xF0) /* First 4 rows of input are non-zero */
     {
         /************************************************************************************************/
         /**********************************START - IT_RECON_8x8******************************************/
@@ -140,7 +140,7 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -149,12 +149,12 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 4; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_8[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_8[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_8[3][k]
-                                                    * pi2_src[3 * i4_src_strd];
+                                                    * pi2_src[3 * src_strd];
                 }
-                eo[0] = g_ai2_ihevc_trans_8[2][0] * pi2_src[2 * i4_src_strd];
-                eo[1] = g_ai2_ihevc_trans_8[2][1] * pi2_src[2 * i4_src_strd];
+                eo[0] = g_ai2_ihevc_trans_8[2][0] * pi2_src[2 * src_strd];
+                eo[1] = g_ai2_ihevc_trans_8[2][1] * pi2_src[2 * src_strd];
                 ee[0] = g_ai2_ihevc_trans_8[0][0] * pi2_src[0];
                 ee[1] = g_ai2_ihevc_trans_8[0][1] * pi2_src[0];
 
@@ -173,7 +173,7 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -212,8 +212,8 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                     pu2_dst[k + 4] = CLIP3((itrans_out + pu2_pred[k + 4] ), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -257,8 +257,8 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                     pu2_dst[k + 4] = CLIP3((itrans_out + pu2_pred[k + 4] ), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/
@@ -278,7 +278,7 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
         for(j = 0; j < row_limit_2nd_stage; j++)
         {
             /* Checking for Zero Cols */
-            if((i4_zero_cols & 1) == 1)
+            if((zero_cols & 1) == 1)
             {
                 memset(pi2_tmp, 0, trans_size * sizeof(WORD16));
             }
@@ -287,23 +287,23 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                 /* Utilizing symmetry properties to the maximum to minimize the number of multiplications */
                 for(k = 0; k < 4; k++)
                 {
-                    o[k] = g_ai2_ihevc_trans_8[1][k] * pi2_src[i4_src_strd]
+                    o[k] = g_ai2_ihevc_trans_8[1][k] * pi2_src[src_strd]
                                     + g_ai2_ihevc_trans_8[3][k]
-                                                    * pi2_src[3 * i4_src_strd]
+                                                    * pi2_src[3 * src_strd]
                                     + g_ai2_ihevc_trans_8[5][k]
-                                                    * pi2_src[5 * i4_src_strd]
+                                                    * pi2_src[5 * src_strd]
                                     + g_ai2_ihevc_trans_8[7][k]
-                                                    * pi2_src[7 * i4_src_strd];
+                                                    * pi2_src[7 * src_strd];
                 }
 
-                eo[0] = g_ai2_ihevc_trans_8[2][0] * pi2_src[2 * i4_src_strd]
-                                + g_ai2_ihevc_trans_8[6][0] * pi2_src[6 * i4_src_strd];
-                eo[1] = g_ai2_ihevc_trans_8[2][1] * pi2_src[2 * i4_src_strd]
-                                + g_ai2_ihevc_trans_8[6][1] * pi2_src[6 * i4_src_strd];
+                eo[0] = g_ai2_ihevc_trans_8[2][0] * pi2_src[2 * src_strd]
+                                + g_ai2_ihevc_trans_8[6][0] * pi2_src[6 * src_strd];
+                eo[1] = g_ai2_ihevc_trans_8[2][1] * pi2_src[2 * src_strd]
+                                + g_ai2_ihevc_trans_8[6][1] * pi2_src[6 * src_strd];
                 ee[0] = g_ai2_ihevc_trans_8[0][0] * pi2_src[0]
-                                + g_ai2_ihevc_trans_8[4][0] * pi2_src[4 * i4_src_strd];
+                                + g_ai2_ihevc_trans_8[4][0] * pi2_src[4 * src_strd];
                 ee[1] = g_ai2_ihevc_trans_8[0][1] * pi2_src[0]
-                                + g_ai2_ihevc_trans_8[4][1] * pi2_src[4 * i4_src_strd];
+                                + g_ai2_ihevc_trans_8[4][1] * pi2_src[4 * src_strd];
 
                 /* Combining e and o terms at each hierarchy levels to calculate the final spatial domain vector */
                 e[0] = ee[0] + eo[0];
@@ -320,7 +320,7 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
             }
             pi2_src++;
             pi2_tmp += trans_size;
-            i4_zero_cols = i4_zero_cols >> 1;
+            zero_cols = zero_cols >> 1;
         }
 
         pi2_tmp = pi2_tmp_orig;
@@ -359,8 +359,8 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                     pu2_dst[k + 4] = CLIP3((itrans_out + pu2_pred[k + 4] ), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         else /* All rows of output of 1st stage are non-zero */
@@ -404,8 +404,8 @@ void ihevc_hbd_itrans_recon_8x8(WORD16 *pi2_src,
                     pu2_dst[k + 4] = CLIP3((itrans_out + pu2_pred[k + 4] ), 0, clip_limit);
                 }
                 pi2_tmp++;
-                pu2_pred += i4_pred_strd;
-                pu2_dst += i4_dst_strd;
+                pu2_pred += pred_strd;
+                pu2_dst += dst_strd;
             }
         }
         /************************************************************************************************/

--- a/common/ihevc_hbd_padding.c
+++ b/common/ihevc_hbd_padding.c
@@ -53,7 +53,7 @@
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -79,7 +79,7 @@
 *******************************************************************************
 */
 void ihevc_hbd_pad_vert(UWORD16 *pu2_src,
-                        WORD32 i4_src_strd,
+                        WORD32 src_strd,
                         WORD32 ht,
                         WORD32 wd,
                         WORD32 pad_size)
@@ -88,9 +88,9 @@ void ihevc_hbd_pad_vert(UWORD16 *pu2_src,
 
     for(row = 1; row <= pad_size; row++)
     {
-        memcpy(pu2_src - row * i4_src_strd, pu2_src, wd * sizeof(UWORD16));
-        memcpy(pu2_src + (ht + row - 1) * i4_src_strd,
-               pu2_src + (ht - 1) * i4_src_strd, wd * sizeof(UWORD16));
+        memcpy(pu2_src - row * src_strd, pu2_src, wd * sizeof(UWORD16));
+        memcpy(pu2_src + (ht + row - 1) * src_strd,
+               pu2_src + (ht - 1) * src_strd, wd * sizeof(UWORD16));
     }
 }
 /**
@@ -105,7 +105,7 @@ void ihevc_hbd_pad_vert(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -131,7 +131,7 @@ void ihevc_hbd_pad_vert(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_horz_chroma(UWORD16 *pu2_src,
-                               WORD32 i4_src_strd,
+                               WORD32 src_strd,
                                WORD32 ht,
                                WORD32 wd,
                                WORD32 pad_size)
@@ -140,7 +140,7 @@ void ihevc_hbd_pad_horz_chroma(UWORD16 *pu2_src,
     WORD32 col;
     UWORD32 *pu4_src = (UWORD32 *)pu2_src;
 
-    i4_src_strd >>= 1;
+    src_strd >>= 1;
     wd >>= 1;
     pad_size >>= 1;
 
@@ -156,7 +156,7 @@ void ihevc_hbd_pad_horz_chroma(UWORD16 *pu2_src,
         for(col = 0; col < pad_size; col++)
             pu4_src[col+wd] = u4_uv_val;
 
-        pu4_src += i4_src_strd;
+        pu4_src += src_strd;
     }
 }
 
@@ -172,7 +172,7 @@ void ihevc_hbd_pad_horz_chroma(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -198,7 +198,7 @@ void ihevc_hbd_pad_horz_chroma(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_horz_luma(UWORD16 *pu2_src,
-                             WORD32 i4_src_strd,
+                             WORD32 src_strd,
                              WORD32 ht,
                              WORD32 wd,
                              WORD32 pad_size)
@@ -212,7 +212,7 @@ void ihevc_hbd_pad_horz_luma(UWORD16 *pu2_src,
             pu2_src[col - pad_size] = *pu2_src;
             pu2_src[col + wd] = *(pu2_src + wd - 1);
         }
-        pu2_src += i4_src_strd;
+        pu2_src += src_strd;
     }
 }
 
@@ -230,7 +230,7 @@ void ihevc_hbd_pad_horz_luma(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -256,7 +256,7 @@ void ihevc_hbd_pad_horz_luma(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_top(UWORD16 *pu2_src,
-                       WORD32 i4_src_strd,
+                       WORD32 src_strd,
                        WORD32 wd,
                        WORD32 pad_size)
 {
@@ -264,7 +264,7 @@ void ihevc_hbd_pad_top(UWORD16 *pu2_src,
 
     for(row = 1; row <= pad_size; row++)
     {
-        memcpy(pu2_src - row * i4_src_strd, pu2_src, wd * sizeof(UWORD16));
+        memcpy(pu2_src - row * src_strd, pu2_src, wd * sizeof(UWORD16));
     }
 }
 
@@ -281,7 +281,7 @@ void ihevc_hbd_pad_top(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -307,7 +307,7 @@ void ihevc_hbd_pad_top(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_bottom(UWORD16 *pu2_src,
-                          WORD32 i4_src_strd,
+                          WORD32 src_strd,
                           WORD32 wd,
                           WORD32 pad_size)
 {
@@ -315,8 +315,8 @@ void ihevc_hbd_pad_bottom(UWORD16 *pu2_src,
 
     for(row = 1; row <= pad_size; row++)
     {
-        memcpy(pu2_src + (row - 1) * i4_src_strd,
-               pu2_src - 1 * i4_src_strd, wd * sizeof(UWORD16));
+        memcpy(pu2_src + (row - 1) * src_strd,
+               pu2_src - 1 * src_strd, wd * sizeof(UWORD16));
     }
 }
 
@@ -334,7 +334,7 @@ void ihevc_hbd_pad_bottom(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -361,7 +361,7 @@ void ihevc_hbd_pad_bottom(UWORD16 *pu2_src,
 */
 
 void ihevc_hbd_pad_left_luma(UWORD16 *pu2_src,
-                             WORD32 i4_src_strd,
+                             WORD32 src_strd,
                              WORD32 ht,
                              WORD32 pad_size)
 {
@@ -373,7 +373,7 @@ void ihevc_hbd_pad_left_luma(UWORD16 *pu2_src,
         {
             pu2_src[col - pad_size] = *pu2_src;
         }
-        pu2_src += i4_src_strd;
+        pu2_src += src_strd;
     }
 }
 
@@ -392,7 +392,7 @@ void ihevc_hbd_pad_left_luma(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -418,7 +418,7 @@ void ihevc_hbd_pad_left_luma(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_left_chroma(UWORD16 *pu2_src,
-                               WORD32 i4_src_strd,
+                               WORD32 src_strd,
                                WORD32 ht,
                                WORD32 pad_size)
 {
@@ -426,7 +426,7 @@ void ihevc_hbd_pad_left_chroma(UWORD16 *pu2_src,
     WORD32 col;
     UWORD32 *pu4_src = (UWORD32 *)pu2_src;
 
-    i4_src_strd >>= 1;
+    src_strd >>= 1;
     pad_size >>= 1;
 
     for(row = 0; row < ht; row++)
@@ -437,7 +437,7 @@ void ihevc_hbd_pad_left_chroma(UWORD16 *pu2_src,
         for(col = -pad_size; col < 0; col++)
             pu4_src[col] = u4_uv_val;
 
-        pu4_src += i4_src_strd;
+        pu4_src += src_strd;
     }
 }
 
@@ -456,7 +456,7 @@ void ihevc_hbd_pad_left_chroma(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -482,7 +482,7 @@ void ihevc_hbd_pad_left_chroma(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_right_luma(UWORD16 *pu2_src,
-                              WORD32 i4_src_strd,
+                              WORD32 src_strd,
                               WORD32 ht,
                               WORD32 pad_size)
 {
@@ -495,7 +495,7 @@ void ihevc_hbd_pad_right_luma(UWORD16 *pu2_src,
             pu2_src[col] = *(pu2_src - 1);
         }
 
-        pu2_src += i4_src_strd;
+        pu2_src += src_strd;
     }
 }
 
@@ -513,7 +513,7 @@ void ihevc_hbd_pad_right_luma(UWORD16 *pu2_src,
 * @param[in] pu1_src
 *  UWORD8 pointer to the source
 *
-* @param[in] i4_src_strd
+* @param[in] src_strd
 *  integer source stride
 *
 * @param[in] ht
@@ -539,7 +539,7 @@ void ihevc_hbd_pad_right_luma(UWORD16 *pu2_src,
 *******************************************************************************
 */
 void ihevc_hbd_pad_right_chroma(UWORD16 *pu2_src,
-                                WORD32 i4_src_strd,
+                                WORD32 src_strd,
                                 WORD32 ht,
                                 WORD32 pad_size)
 {
@@ -547,7 +547,7 @@ void ihevc_hbd_pad_right_chroma(UWORD16 *pu2_src,
     WORD32 col;
     UWORD32 *pu4_src = (UWORD32 *)pu2_src;
 
-    i4_src_strd >>= 1;
+    src_strd >>= 1;
     pad_size >>= 1;
 
     for(row = 0; row < ht; row++)
@@ -558,7 +558,7 @@ void ihevc_hbd_pad_right_chroma(UWORD16 *pu2_src,
         for(col = 0; col < pad_size; col++)
             pu4_src[col] = u4_uv_val;
 
-        pu4_src += i4_src_strd;
+        pu4_src += src_strd;
     }
 }
 

--- a/common/ihevc_hbd_recon.c
+++ b/common/ihevc_hbd_recon.c
@@ -71,16 +71,16 @@
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -93,10 +93,10 @@
 void ihevc_hbd_recon_4x4_ttype1(WORD16 *pi2_src,
                                 UWORD16 *pu2_pred,
                                 UWORD16 *pu2_dst,
-                                WORD32 i4_src_strd,
-                                WORD32 i4_pred_strd,
-                                WORD32 i4_dst_strd,
-                                WORD32 i4_zero_cols,
+                                WORD32 src_strd,
+                                WORD32 pred_strd,
+                                WORD32 dst_strd,
+                                WORD32 zero_cols,
                                 UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -111,25 +111,25 @@ void ihevc_hbd_recon_4x4_ttype1(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                                CLIP3((pi2_src[j*i4_src_strd] + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                                CLIP3((pi2_src[j*src_strd] + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst++;
         pu2_pred++;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -151,19 +151,19 @@ void ihevc_hbd_recon_4x4_ttype1(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 4x4 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -176,10 +176,10 @@ void ihevc_hbd_recon_4x4_ttype1(WORD16 *pi2_src,
 void ihevc_hbd_recon_4x4(WORD16 *pi2_src,
                          UWORD16 *pu2_pred,
                          UWORD16 *pu2_dst,
-                         WORD32 i4_src_strd,
-                         WORD32 i4_pred_strd,
-                         WORD32 i4_dst_strd,
-                         WORD32 i4_zero_cols,
+                         WORD32 src_strd,
+                         WORD32 pred_strd,
+                         WORD32 dst_strd,
+                         WORD32 zero_cols,
                          UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -194,25 +194,25 @@ void ihevc_hbd_recon_4x4(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                                CLIP3((pi2_src[j*i4_src_strd] + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                                CLIP3((pi2_src[j*src_strd] + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst++;
         pu2_pred++;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -234,19 +234,19 @@ void ihevc_hbd_recon_4x4(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 8x8 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -259,10 +259,10 @@ void ihevc_hbd_recon_4x4(WORD16 *pi2_src,
 void ihevc_hbd_recon_8x8(WORD16 *pi2_src,
                          UWORD16 *pu2_pred,
                          UWORD16 *pu2_dst,
-                         WORD32 i4_src_strd,
-                         WORD32 i4_pred_strd,
-                         WORD32 i4_dst_strd,
-                         WORD32 i4_zero_cols,
+                         WORD32 src_strd,
+                         WORD32 pred_strd,
+                         WORD32 dst_strd,
+                         WORD32 zero_cols,
                          UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -277,25 +277,25 @@ void ihevc_hbd_recon_8x8(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                                CLIP3((pi2_src[j*i4_src_strd] + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                                CLIP3((pi2_src[j*src_strd] + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst++;
         pu2_pred++;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -317,19 +317,19 @@ void ihevc_hbd_recon_8x8(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 16x16 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -342,10 +342,10 @@ void ihevc_hbd_recon_8x8(WORD16 *pi2_src,
 void ihevc_hbd_recon_16x16(WORD16 *pi2_src,
                            UWORD16 *pu2_pred,
                            UWORD16 *pu2_dst,
-                           WORD32 i4_src_strd,
-                           WORD32 i4_pred_strd,
-                           WORD32 i4_dst_strd,
-                           WORD32 i4_zero_cols,
+                           WORD32 src_strd,
+                           WORD32 pred_strd,
+                           WORD32 dst_strd,
+                           WORD32 zero_cols,
                            UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -360,25 +360,25 @@ void ihevc_hbd_recon_16x16(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                                CLIP3((pi2_src[j*i4_src_strd] + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                                CLIP3((pi2_src[j*src_strd] + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst++;
         pu2_pred++;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }
 /**
@@ -400,19 +400,19 @@ void ihevc_hbd_recon_16x16(WORD16 *pi2_src,
  * @param[out] pu2_dst
  *  Output 32x32 block
  *
- * @param[in] i4_src_strd
+ * @param[in] src_strd
  *  Input stride
  *
- * @param[in] i4_pred_strd
+ * @param[in] pred_strd
  *  Prediction stride
  *
- * @param[in] i4_dst_strd
+ * @param[in] dst_strd
  *  Output Stride
  *
  * @param[in] shift
  *  Output shift
  *
- * @param[in] i4_zero_cols
+ * @param[in] zero_cols
  *  Zero columns in pi2_tmp
  *
  * @returns  Void
@@ -425,10 +425,10 @@ void ihevc_hbd_recon_16x16(WORD16 *pi2_src,
 void ihevc_hbd_recon_32x32(WORD16 *pi2_src,
                            UWORD16 *pu2_pred,
                            UWORD16 *pu2_dst,
-                           WORD32 i4_src_strd,
-                           WORD32 i4_pred_strd,
-                           WORD32 i4_dst_strd,
-                           WORD32 i4_zero_cols,
+                           WORD32 src_strd,
+                           WORD32 pred_strd,
+                           WORD32 dst_strd,
+                           WORD32 zero_cols,
                            UWORD8 u1_bit_depth)
 {
     WORD32 i, j;
@@ -443,24 +443,24 @@ void ihevc_hbd_recon_32x32(WORD16 *pi2_src,
     for(i = 0; i < trans_size; i++)
     {
         /* Checking for Zero Cols */
-        if((i4_zero_cols & 1) == 1)
+        if((zero_cols & 1) == 1)
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] = pu2_pred[j * i4_pred_strd];
+                pu2_dst[j * dst_strd] = pu2_pred[j * pred_strd];
             }
         }
         else
         {
             for(j = 0; j < trans_size; j++)
             {
-                pu2_dst[j * i4_dst_strd] =
-                                CLIP3((pi2_src[j*i4_src_strd] + pu2_pred[j*i4_pred_strd]), 0, clip_limit);
+                pu2_dst[j * dst_strd] =
+                                CLIP3((pi2_src[j*src_strd] + pu2_pred[j*pred_strd]), 0, clip_limit);
             }
         }
         pi2_src++;
         pu2_dst++;
         pu2_pred++;
-        i4_zero_cols = i4_zero_cols >> 1;
+        zero_cols = zero_cols >> 1;
     }
 }

--- a/common/ihevc_hbd_sao.c
+++ b/common/ihevc_hbd_sao.c
@@ -61,14 +61,14 @@
  * au4_avail[7] - bottom-right
  */
 void ihevc_hbd_sao_band_offset_luma(UWORD16 *pu2_src,
-                                    WORD32 i4_src_strd,
+                                    WORD32 src_strd,
                                     UWORD16 *pu2_src_left,
                                     UWORD16 *pu2_src_top,
                                     UWORD16 *pu2_src_top_left,
-                                    WORD32 i4_sao_band_pos,
+                                    WORD32 sao_band_pos,
                                     WORD8 *pi1_sao_offset,
-                                    WORD32 i4_wd,
-                                    WORD32 i4_ht,
+                                    WORD32 wd,
+                                    WORD32 ht,
                                     UWORD32 u4_bit_depth)
 {
     WORD32 band_shift;
@@ -77,14 +77,14 @@ void ihevc_hbd_sao_band_offset_luma(UWORD16 *pu2_src,
     WORD32 row, col;
 
     /* Updating left and top and top-left */
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
-        pu2_src_left[row] = pu2_src[row * i4_src_strd + (i4_wd - 1)];
+        pu2_src_left[row] = pu2_src[row * src_strd + (wd - 1)];
     }
-    pu2_src_top_left[0] = pu2_src_top[i4_wd - 1];
-    for(col = 0; col < i4_wd; col++)
+    pu2_src_top_left[0] = pu2_src_top[wd - 1];
+    for(col = 0; col < wd; col++)
     {
-        pu2_src_top[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        pu2_src_top[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     band_shift = u4_bit_depth - 5;
@@ -94,12 +94,12 @@ void ihevc_hbd_sao_band_offset_luma(UWORD16 *pu2_src,
     }
     for(i = 0; i < 4; i++)
     {
-        band_table[(i + i4_sao_band_pos) & 31] = i + 1;
+        band_table[(i + sao_band_pos) & 31] = i + 1;
     }
 
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
-        for(col = 0; col < i4_wd; col++)
+        for(col = 0; col < wd; col++)
         {
             WORD32 band_idx;
             WORD32 idx = pu2_src[col] >> band_shift;
@@ -107,21 +107,21 @@ void ihevc_hbd_sao_band_offset_luma(UWORD16 *pu2_src,
             band_idx = (idx < NUM_BAND_TABLE) ? band_table[idx] : 0;
             pu2_src[col] = CLIP3(pu2_src[col] + pi1_sao_offset[band_idx], 0, (1 << (band_shift + 5)) - 1);
         }
-        pu2_src += i4_src_strd;
+        pu2_src += src_strd;
     }
 }
 
 void ihevc_hbd_sao_band_offset_chroma(UWORD16 *pu2_src,
-                                      WORD32 i4_src_strd,
+                                      WORD32 src_strd,
                                       UWORD16 *pu2_src_left,
                                       UWORD16 *pu2_src_top,
                                       UWORD16 *pu2_src_top_left,
-                                      WORD32 i4_sao_band_pos_u,
-                                      WORD32 i4_sao_band_pos_v,
+                                      WORD32 sao_band_pos_u,
+                                      WORD32 sao_band_pos_v,
                                       WORD8 *pi1_sao_offset_u,
                                       WORD8 *pi1_sao_offset_v,
-                                      WORD32 i4_wd,
-                                      WORD32 i4_ht,
+                                      WORD32 wd,
+                                      WORD32 ht,
                                       UWORD32 u4_bit_depth)
 {
     WORD32 band_shift;
@@ -131,16 +131,16 @@ void ihevc_hbd_sao_band_offset_chroma(UWORD16 *pu2_src,
     WORD32 row, col;
 
     /* Updating left and top and top-left */
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
-        pu2_src_left[2 * row] = pu2_src[row * i4_src_strd + (i4_wd - 2)];
-        pu2_src_left[2 * row + 1] = pu2_src[row * i4_src_strd + (i4_wd - 1)];
+        pu2_src_left[2 * row] = pu2_src[row * src_strd + (wd - 2)];
+        pu2_src_left[2 * row + 1] = pu2_src[row * src_strd + (wd - 1)];
     }
-    pu2_src_top_left[0] = pu2_src_top[i4_wd - 2];
-    pu2_src_top_left[1] = pu2_src_top[i4_wd - 1];
-    for(col = 0; col < i4_wd; col++)
+    pu2_src_top_left[0] = pu2_src_top[wd - 2];
+    pu2_src_top_left[1] = pu2_src_top[wd - 1];
+    for(col = 0; col < wd; col++)
     {
-        pu2_src_top[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        pu2_src_top[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     band_shift = u4_bit_depth - 5;
@@ -151,13 +151,13 @@ void ihevc_hbd_sao_band_offset_chroma(UWORD16 *pu2_src,
     }
     for(i = 0; i < 4; i++)
     {
-        band_table_u[(i + i4_sao_band_pos_u) & 31] = i + 1;
-        band_table_v[(i + i4_sao_band_pos_v) & 31] = i + 1;
+        band_table_u[(i + sao_band_pos_u) & 31] = i + 1;
+        band_table_v[(i + sao_band_pos_v) & 31] = i + 1;
     }
 
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
-        for(col = 0; col < i4_wd; col++)
+        for(col = 0; col < wd; col++)
         {
             WORD32 band_idx;
             WORD8 *pi1_sao_offset;
@@ -174,12 +174,12 @@ void ihevc_hbd_sao_band_offset_chroma(UWORD16 *pu2_src,
             }
             pu2_src[col] = CLIP3(pu2_src[col] + pi1_sao_offset[band_idx], 0, (1 << (band_shift + 5)) - 1);
         }
-        pu2_src += i4_src_strd;
+        pu2_src += src_strd;
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class0(UWORD16 *pu2_src,
-                                      WORD32 i4_src_strd,
+                                      WORD32 src_strd,
                                       UWORD16 *pu2_src_left,
                                       UWORD16 *pu2_src_top,
                                       UWORD16 *pu2_src_top_left,
@@ -187,8 +187,8 @@ void ihevc_hbd_sao_edge_offset_class0(UWORD16 *pu2_src,
                                       UWORD16 *pu2_src_bot_left,
                                       UWORD8 *pu1_avail,
                                       WORD8 *pi1_sao_offset,
-                                      WORD32 i4_wd,
-                                      WORD32 i4_ht,
+                                      WORD32 wd,
+                                      WORD32 ht,
                                       UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -200,14 +200,14 @@ void ihevc_hbd_sao_edge_offset_class0(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update top and top-left arrays */
-    *pu2_src_top_left = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    *pu2_src_top_left = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        au2_src_left_tmp[row] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        au2_src_left_tmp[row] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        pu2_src_top[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        pu2_src_top[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* Update masks based on the availability flags */
@@ -217,15 +217,15 @@ void ihevc_hbd_sao_edge_offset_class0(UWORD16 *pu2_src,
     }
     if(0 == pu1_avail[1])
     {
-        au1_mask[i4_wd - 1] = 0;
+        au1_mask[wd - 1] = 0;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
             u1_sign_left = SIGN(pu2_src[0] - pu2_src_left[row]);
-            for(col = 0; col < i4_wd; col++)
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
 
@@ -241,19 +241,19 @@ void ihevc_hbd_sao_edge_offset_class0(UWORD16 *pu2_src,
                 }
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
     }
 
     /* Update left array */
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
         pu2_src_left[row] = au2_src_left_tmp[row];
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class0_chroma(UWORD16 *pu2_src,
-                                             WORD32 i4_src_strd,
+                                             WORD32 src_strd,
                                              UWORD16 *pu2_src_left,
                                              UWORD16 *pu2_src_top,
                                              UWORD16 *pu2_src_top_left,
@@ -262,8 +262,8 @@ void ihevc_hbd_sao_edge_offset_class0_chroma(UWORD16 *pu2_src,
                                              UWORD8 *pu1_avail,
                                              WORD8 *pi1_sao_offset_u,
                                              WORD8 *pi1_sao_offset_v,
-                                             WORD32 i4_wd,
-                                             WORD32 i4_ht,
+                                             WORD32 wd,
+                                             WORD32 ht,
                                              UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -276,16 +276,16 @@ void ihevc_hbd_sao_edge_offset_class0_chroma(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    pu2_src_top_left[0] = pu2_src_top[i4_wd - 2];
-    pu2_src_top_left[1] = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    pu2_src_top_left[0] = pu2_src_top[wd - 2];
+    pu2_src_top_left[1] = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        au2_src_left_tmp[2 * row] = pu2_src[row * i4_src_strd + i4_wd - 2];
-        au2_src_left_tmp[2 * row + 1] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        au2_src_left_tmp[2 * row] = pu2_src[row * src_strd + wd - 2];
+        au2_src_left_tmp[2 * row + 1] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        pu2_src_top[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        pu2_src_top[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* Update masks based on the availability flags */
@@ -295,16 +295,16 @@ void ihevc_hbd_sao_edge_offset_class0_chroma(UWORD16 *pu2_src,
     }
     if(0 == pu1_avail[1])
     {
-        au1_mask[(i4_wd - 1) >> 1] = 0;
+        au1_mask[(wd - 1) >> 1] = 0;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
             u1_sign_left_u = SIGN(pu2_src[0] - pu2_src_left[2 * row]);
             u1_sign_left_v = SIGN(pu2_src[1] - pu2_src_left[2 * row + 1]);
-            for(col = 0; col < i4_wd; col++)
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
                 WORD8 *pi1_sao_offset;
@@ -332,18 +332,18 @@ void ihevc_hbd_sao_edge_offset_class0_chroma(UWORD16 *pu2_src,
                 }
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
     }
 
-    for(row = 0; row < 2 * i4_ht; row++)
+    for(row = 0; row < 2 * ht; row++)
     {
         pu2_src_left[row] = au2_src_left_tmp[row];
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class1(UWORD16 *pu2_src,
-                                      WORD32 i4_src_strd,
+                                      WORD32 src_strd,
                                       UWORD16 *pu2_src_left,
                                       UWORD16 *pu2_src_top,
                                       UWORD16 *pu2_src_top_left,
@@ -351,8 +351,8 @@ void ihevc_hbd_sao_edge_offset_class1(UWORD16 *pu2_src,
                                       UWORD16 *pu2_src_bot_left,
                                       UWORD8 *pu1_avail,
                                       WORD8 *pi1_sao_offset,
-                                      WORD32 i4_wd,
-                                      WORD32 i4_ht,
+                                      WORD32 wd,
+                                      WORD32 ht,
                                       UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -365,47 +365,47 @@ void ihevc_hbd_sao_edge_offset_class1(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    *pu2_src_top_left = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    *pu2_src_top_left = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        pu2_src_left[row] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        pu2_src_left[row] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        au2_src_top_tmp[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        au2_src_top_tmp[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* Update height and source pointers based on the availability flags */
     if(0 == pu1_avail[2])
     {
-        pu2_src += i4_src_strd;
-        i4_ht--;
-        for(col = 0; col < i4_wd; col++)
+        pu2_src += src_strd;
+        ht--;
+        for(col = 0; col < wd; col++)
         {
-            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - i4_src_strd]);
+            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - src_strd]);
         }
     }
     else
     {
-        for(col = 0; col < i4_wd; col++)
+        for(col = 0; col < wd; col++)
         {
             au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src_top[col]);
         }
     }
     if(0 == pu1_avail[3])
     {
-        i4_ht--;
+        ht--;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
-            for(col = 0; col < i4_wd; col++)
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
 
-                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + i4_src_strd]);
+                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + src_strd]);
                 edge_idx = 2 + au1_sign_up[col] + u1_sign_down;
                 au1_sign_up[col] = -u1_sign_down;
 
@@ -417,18 +417,18 @@ void ihevc_hbd_sao_edge_offset_class1(UWORD16 *pu2_src,
                 }
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
     }
 
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
         pu2_src_top[col] = au2_src_top_tmp[col];
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class1_chroma(UWORD16 *pu2_src,
-                                             WORD32 i4_src_strd,
+                                             WORD32 src_strd,
                                              UWORD16 *pu2_src_left,
                                              UWORD16 *pu2_src_top,
                                              UWORD16 *pu2_src_top_left,
@@ -437,8 +437,8 @@ void ihevc_hbd_sao_edge_offset_class1_chroma(UWORD16 *pu2_src,
                                              UWORD8 *pu1_avail,
                                              WORD8 *pi1_sao_offset_u,
                                              WORD8 *pi1_sao_offset_v,
-                                             WORD32 i4_wd,
-                                             WORD32 i4_ht,
+                                             WORD32 wd,
+                                             WORD32 ht,
                                              UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -451,52 +451,52 @@ void ihevc_hbd_sao_edge_offset_class1_chroma(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    pu2_src_top_left[0] = pu2_src_top[i4_wd - 2];
-    pu2_src_top_left[1] = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    pu2_src_top_left[0] = pu2_src_top[wd - 2];
+    pu2_src_top_left[1] = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        pu2_src_left[2 * row] = pu2_src[row * i4_src_strd + i4_wd - 2];
-        pu2_src_left[2 * row + 1] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        pu2_src_left[2 * row] = pu2_src[row * src_strd + wd - 2];
+        pu2_src_left[2 * row + 1] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        au2_src_top_tmp[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        au2_src_top_tmp[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* Update height and source pointers based on the availability flags */
     if(0 == pu1_avail[2])
     {
-        pu2_src += i4_src_strd;
-        i4_ht--;
-        for(col = 0; col < i4_wd; col++)
+        pu2_src += src_strd;
+        ht--;
+        for(col = 0; col < wd; col++)
         {
-            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - i4_src_strd]);
+            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - src_strd]);
         }
     }
     else
     {
-        for(col = 0; col < i4_wd; col++)
+        for(col = 0; col < wd; col++)
         {
             au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src_top[col]);
         }
     }
     if(0 == pu1_avail[3])
     {
-        i4_ht--;
+        ht--;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
-            for(col = 0; col < i4_wd; col++)
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
                 WORD8 *pi1_sao_offset;
 
                 pi1_sao_offset = (0 == col % 2) ? pi1_sao_offset_u : pi1_sao_offset_v;
 
-                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + i4_src_strd]);
+                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + src_strd]);
                 edge_idx = 2 + au1_sign_up[col] + u1_sign_down;
                 au1_sign_up[col] = -u1_sign_down;
 
@@ -508,18 +508,18 @@ void ihevc_hbd_sao_edge_offset_class1_chroma(UWORD16 *pu2_src,
                 }
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
     }
 
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
         pu2_src_top[col] = au2_src_top_tmp[col];
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
-                                      WORD32 i4_src_strd,
+                                      WORD32 src_strd,
                                       UWORD16 *pu2_src_left,
                                       UWORD16 *pu2_src_top,
                                       UWORD16 *pu2_src_top_left,
@@ -527,8 +527,8 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
                                       UWORD16 *pu2_src_bot_left,
                                       UWORD8 *pu1_avail,
                                       WORD8 *pi1_sao_offset,
-                                      WORD32 i4_wd,
-                                      WORD32 i4_ht,
+                                      WORD32 wd,
+                                      WORD32 ht,
                                       UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -552,14 +552,14 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    u2_src_top_left_tmp = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    u2_src_top_left_tmp = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        au2_src_left_tmp[row] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        au2_src_left_tmp[row] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        au2_src_top_tmp[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        au2_src_top_tmp[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* If top-left is available, process separately */
@@ -568,7 +568,7 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
         WORD32 edge_idx;
 
         edge_idx = 2 + SIGN(pu2_src[0] - pu2_src_top_left[0]) +
-                        SIGN(pu2_src[0] - pu2_src[1 + i4_src_strd]);
+                        SIGN(pu2_src[0] - pu2_src[1 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
@@ -591,23 +591,23 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
     {
         WORD32 edge_idx;
 
-        edge_idx = 2 + SIGN(pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd] - pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd- 1 - i4_src_strd]) +
-                        SIGN(pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd] - pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd + 1 + i4_src_strd]);
+        edge_idx = 2 + SIGN(pu2_src[wd - 1 + (ht - 1) * src_strd] - pu2_src[wd - 1 + (ht - 1) * src_strd- 1 - src_strd]) +
+                        SIGN(pu2_src[wd - 1 + (ht - 1) * src_strd] - pu2_src[wd - 1 + (ht - 1) * src_strd + 1 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_wd_ht_tmp = CLIP3(pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd] + pi1_sao_offset[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_wd_ht_tmp = CLIP3(pu2_src[wd - 1 + (ht - 1) * src_strd] + pi1_sao_offset[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_wd_ht_tmp = pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd];
+            u2_pos_wd_ht_tmp = pu2_src[wd - 1 + (ht - 1) * src_strd];
         }
     }
     else
     {
-        u2_pos_wd_ht_tmp = pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd];
+        u2_pos_wd_ht_tmp = pu2_src[wd - 1 + (ht - 1) * src_strd];
     }
 
     /* If Left is not available */
@@ -619,17 +619,17 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
     /* If Top is not available */
     if(0 == pu1_avail[2])
     {
-        pu2_src += i4_src_strd;
-        i4_ht--;
+        pu2_src += src_strd;
+        ht--;
         pu2_src_left_cpy += 1;
-        for(col = 1;col < i4_wd; col++)
+        for(col = 1;col < wd; col++)
         {
-            pu1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - 1 - i4_src_strd]);
+            pu1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - 1 - src_strd]);
         }
     }
     else
     {
-        for(col = 1;col < i4_wd; col++)
+        for(col = 1;col < wd; col++)
         {
             pu1_sign_up[col] = SIGN(pu2_src[col] - pu2_src_top[col - 1]);
         }
@@ -638,25 +638,25 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
     /* If Right is not available */
     if(0 == pu1_avail[1])
     {
-        au1_mask[i4_wd - 1] = 0;
+        au1_mask[wd - 1] = 0;
     }
 
     /* If Bottom is not available */
     if(0 == pu1_avail[3])
     {
-        i4_ht--;
+        ht--;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
             pu1_sign_up[0] = SIGN(pu2_src[0] - pu2_src_left_cpy[row - 1]);
-            for(col = 0; col < i4_wd; col++)
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
 
-                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + 1 + i4_src_strd]);
+                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + 1 + src_strd]);
                 edge_idx = 2 + pu1_sign_up[col] + u1_sign_down;
                 pu1_sign_up_tmp[col + 1] = -u1_sign_down;
 
@@ -675,30 +675,30 @@ void ihevc_hbd_sao_edge_offset_class2(UWORD16 *pu2_src,
                 pu1_sign_up_tmp = pu1_swap_tmp;
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
 
-        pu2_src[- (pu1_avail[2] ? i4_ht : i4_ht + 1) * i4_src_strd] = u2_pos_0_0_tmp;
-        pu2_src[(pu1_avail[3] ? i4_wd - 1 - i4_src_strd : i4_wd - 1)] = u2_pos_wd_ht_tmp;
+        pu2_src[- (pu1_avail[2] ? ht : ht + 1) * src_strd] = u2_pos_0_0_tmp;
+        pu2_src[(pu1_avail[3] ? wd - 1 - src_strd : wd - 1)] = u2_pos_wd_ht_tmp;
     }
 
     if(0 == pu1_avail[2])
-        i4_ht++;
+        ht++;
     if(0 == pu1_avail[3])
-        i4_ht++;
+        ht++;
     *pu2_src_top_left = u2_src_top_left_tmp;
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
         pu2_src_left[row] = au2_src_left_tmp[row];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
         pu2_src_top[col] = au2_src_top_tmp[col];
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
-                                             WORD32 i4_src_strd,
+                                             WORD32 src_strd,
                                              UWORD16 *pu2_src_left,
                                              UWORD16 *pu2_src_top,
                                              UWORD16 *pu2_src_top_left,
@@ -707,8 +707,8 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
                                              UWORD8 *pu1_avail,
                                              WORD8 *pi1_sao_offset_u,
                                              WORD8 *pi1_sao_offset_v,
-                                             WORD32 i4_wd,
-                                             WORD32 i4_ht,
+                                             WORD32 wd,
+                                             WORD32 ht,
                                              UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -734,16 +734,16 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    au2_src_top_left_tmp[0] = pu2_src_top[i4_wd - 2];
-    au2_src_top_left_tmp[1] = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    au2_src_top_left_tmp[0] = pu2_src_top[wd - 2];
+    au2_src_top_left_tmp[1] = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        au2_src_left_tmp[2 * row] = pu2_src[row * i4_src_strd + i4_wd - 2];
-        au2_src_left_tmp[2 * row + 1] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        au2_src_left_tmp[2 * row] = pu2_src[row * src_strd + wd - 2];
+        au2_src_left_tmp[2 * row + 1] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        au2_src_top_tmp[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        au2_src_top_tmp[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* If top-left is available, process separately */
@@ -753,7 +753,7 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
 
         /* U */
         edge_idx = 2 + SIGN(pu2_src[0] - pu2_src_top_left[0]) +
-                        SIGN(pu2_src[0] - pu2_src[2 + i4_src_strd]);
+                        SIGN(pu2_src[0] - pu2_src[2 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
@@ -768,7 +768,7 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
 
         /* V */
         edge_idx = 2 + SIGN(pu2_src[1] - pu2_src_top_left[1]) +
-                        SIGN(pu2_src[1] - pu2_src[1 + 2 + i4_src_strd]);
+                        SIGN(pu2_src[1] - pu2_src[1 + 2 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
@@ -793,39 +793,39 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
         WORD32 edge_idx;
 
         /* U */
-        edge_idx = 2 + SIGN(pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd] - pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd - 2 - i4_src_strd]) +
-                        SIGN(pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd] - pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd + 2 + i4_src_strd]);
+        edge_idx = 2 + SIGN(pu2_src[wd - 2 + (ht - 1) * src_strd] - pu2_src[wd - 2 + (ht - 1) * src_strd - 2 - src_strd]) +
+                        SIGN(pu2_src[wd - 2 + (ht - 1) * src_strd] - pu2_src[wd - 2 + (ht - 1) * src_strd + 2 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_wd_ht_tmp_u = CLIP3(pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd] + pi1_sao_offset_u[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_wd_ht_tmp_u = CLIP3(pu2_src[wd - 2 + (ht - 1) * src_strd] + pi1_sao_offset_u[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_wd_ht_tmp_u = pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd];
+            u2_pos_wd_ht_tmp_u = pu2_src[wd - 2 + (ht - 1) * src_strd];
         }
 
         /* V */
-        edge_idx = 2 + SIGN(pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd] - pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd - 2 - i4_src_strd]) +
-                        SIGN(pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd] - pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd + 2 + i4_src_strd]);
+        edge_idx = 2 + SIGN(pu2_src[wd - 1 + (ht - 1) * src_strd] - pu2_src[wd - 1 + (ht - 1) * src_strd - 2 - src_strd]) +
+                        SIGN(pu2_src[wd - 1 + (ht - 1) * src_strd] - pu2_src[wd - 1 + (ht - 1) * src_strd + 2 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_wd_ht_tmp_v = CLIP3(pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd] + pi1_sao_offset_v[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_wd_ht_tmp_v = CLIP3(pu2_src[wd - 1 + (ht - 1) * src_strd] + pi1_sao_offset_v[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_wd_ht_tmp_v = pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd];
+            u2_pos_wd_ht_tmp_v = pu2_src[wd - 1 + (ht - 1) * src_strd];
         }
     }
     else
     {
-        u2_pos_wd_ht_tmp_u = pu2_src[i4_wd - 2 + (i4_ht - 1) * i4_src_strd];
-        u2_pos_wd_ht_tmp_v = pu2_src[i4_wd - 1 + (i4_ht - 1) * i4_src_strd];
+        u2_pos_wd_ht_tmp_u = pu2_src[wd - 2 + (ht - 1) * src_strd];
+        u2_pos_wd_ht_tmp_v = pu2_src[wd - 1 + (ht - 1) * src_strd];
     }
 
     /* If Left is not available */
@@ -837,17 +837,17 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
     /* If Top is not available */
     if(0 == pu1_avail[2])
     {
-        pu2_src += i4_src_strd;
+        pu2_src += src_strd;
         pu2_src_left_cpy += 2;
-        i4_ht--;
-        for(col = 2; col < i4_wd; col++)
+        ht--;
+        for(col = 2; col < wd; col++)
         {
-            pu1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - 2 - i4_src_strd]);
+            pu1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col - 2 - src_strd]);
         }
     }
     else
     {
-        for(col = 2; col < i4_wd; col++)
+        for(col = 2; col < wd; col++)
         {
             pu1_sign_up[col] = SIGN(pu2_src[col] - pu2_src_top[col - 2]);
         }
@@ -856,29 +856,29 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
     /* If Right is not available */
     if(0 == pu1_avail[1])
     {
-        au1_mask[(i4_wd - 1) >> 1] = 0;
+        au1_mask[(wd - 1) >> 1] = 0;
     }
 
     /* If Bottom is not available */
     if(0 == pu1_avail[3])
     {
-        i4_ht--;
+        ht--;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
             pu1_sign_up[0] = SIGN(pu2_src[0] - pu2_src_left_cpy[2 * (row - 1)]);
             pu1_sign_up[1] = SIGN(pu2_src[1] - pu2_src_left_cpy[2 * (row - 1) + 1]);
-            for(col = 0; col < i4_wd; col++)
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
                 WORD8 *pi1_sao_offset;
 
                 pi1_sao_offset = (0 == col % 2) ? pi1_sao_offset_u : pi1_sao_offset_v;
 
-                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + 2 + i4_src_strd]);
+                u1_sign_down = SIGN(pu2_src[col] - pu2_src[col + 2 + src_strd]);
                 edge_idx = 2 + pu1_sign_up[col] + u1_sign_down;
                 pu1_sign_up_tmp[col + 2] = -u1_sign_down;
 
@@ -897,33 +897,33 @@ void ihevc_hbd_sao_edge_offset_class2_chroma(UWORD16 *pu2_src,
                 pu1_sign_up_tmp = pu1_swap_tmp;
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
 
-        pu2_src[- (pu1_avail[2] ? i4_ht : i4_ht + 1) * i4_src_strd] = u2_pos_0_0_tmp_u;
-        pu2_src[- (pu1_avail[2] ? i4_ht : i4_ht + 1) * i4_src_strd + 1] = u2_pos_0_0_tmp_v;
-        pu2_src[(pu1_avail[3] ? i4_wd - 2 - i4_src_strd : i4_wd - 2)] = u2_pos_wd_ht_tmp_u;
-        pu2_src[(pu1_avail[3] ? i4_wd - 1 - i4_src_strd : i4_wd - 1)] = u2_pos_wd_ht_tmp_v;
+        pu2_src[- (pu1_avail[2] ? ht : ht + 1) * src_strd] = u2_pos_0_0_tmp_u;
+        pu2_src[- (pu1_avail[2] ? ht : ht + 1) * src_strd + 1] = u2_pos_0_0_tmp_v;
+        pu2_src[(pu1_avail[3] ? wd - 2 - src_strd : wd - 2)] = u2_pos_wd_ht_tmp_u;
+        pu2_src[(pu1_avail[3] ? wd - 1 - src_strd : wd - 1)] = u2_pos_wd_ht_tmp_v;
     }
 
     if(0 == pu1_avail[2])
-        i4_ht++;
+        ht++;
     if(0 == pu1_avail[3])
-        i4_ht++;
+        ht++;
     pu2_src_top_left[0] = au2_src_top_left_tmp[0];
     pu2_src_top_left[1] = au2_src_top_left_tmp[1];
-    for(row = 0; row < 2 * i4_ht; row++)
+    for(row = 0; row < 2 * ht; row++)
     {
         pu2_src_left[row] = au2_src_left_tmp[row];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
         pu2_src_top[col] = au2_src_top_tmp[col];
     }
 }
 
 void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
-                                      WORD32 i4_src_strd,
+                                      WORD32 src_strd,
                                       UWORD16 *pu2_src_left,
                                       UWORD16 *pu2_src_top,
                                       UWORD16 *pu2_src_top_left,
@@ -931,8 +931,8 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
                                       UWORD16 *pu2_src_bot_left,
                                       UWORD8 *pu1_avail,
                                       WORD8 *pi1_sao_offset,
-                                      WORD32 i4_wd,
-                                      WORD32 i4_ht,
+                                      WORD32 wd,
+                                      WORD32 ht,
                                       UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -953,14 +953,14 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    u2_src_top_left_tmp = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    u2_src_top_left_tmp = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        au2_src_left_tmp[row] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        au2_src_left_tmp[row] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        au2_src_top_tmp[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        au2_src_top_tmp[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* If top-right is available, process separately */
@@ -968,23 +968,23 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
     {
         WORD32 edge_idx;
 
-        edge_idx = 2 + SIGN(pu2_src[i4_wd - 1] - pu2_src_top_right[0]) +
-                        SIGN(pu2_src[i4_wd - 1] - pu2_src[i4_wd - 1 - 1 + i4_src_strd]);
+        edge_idx = 2 + SIGN(pu2_src[wd - 1] - pu2_src_top_right[0]) +
+                        SIGN(pu2_src[wd - 1] - pu2_src[wd - 1 - 1 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_wd_0_tmp = CLIP3(pu2_src[i4_wd - 1] + pi1_sao_offset[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_wd_0_tmp = CLIP3(pu2_src[wd - 1] + pi1_sao_offset[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_wd_0_tmp = pu2_src[i4_wd - 1];
+            u2_pos_wd_0_tmp = pu2_src[wd - 1];
         }
     }
     else
     {
-        u2_pos_wd_0_tmp = pu2_src[i4_wd - 1];
+        u2_pos_wd_0_tmp = pu2_src[wd - 1];
     }
 
     /* If bottom-left is available, process separately */
@@ -992,23 +992,23 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
     {
         WORD32 edge_idx;
 
-        edge_idx = 2 + SIGN(pu2_src[(i4_ht - 1) * i4_src_strd] - pu2_src[(i4_ht - 1) * i4_src_strd + 1 - i4_src_strd]) +
-                        SIGN(pu2_src[(i4_ht - 1) * i4_src_strd] - pu2_src_bot_left[0]);
+        edge_idx = 2 + SIGN(pu2_src[(ht - 1) * src_strd] - pu2_src[(ht - 1) * src_strd + 1 - src_strd]) +
+                        SIGN(pu2_src[(ht - 1) * src_strd] - pu2_src_bot_left[0]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_0_ht_tmp = CLIP3(pu2_src[(i4_ht - 1) * i4_src_strd] + pi1_sao_offset[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_0_ht_tmp = CLIP3(pu2_src[(ht - 1) * src_strd] + pi1_sao_offset[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_0_ht_tmp = pu2_src[(i4_ht - 1) * i4_src_strd];
+            u2_pos_0_ht_tmp = pu2_src[(ht - 1) * src_strd];
         }
     }
     else
     {
-        u2_pos_0_ht_tmp = pu2_src[(i4_ht - 1) * i4_src_strd];
+        u2_pos_0_ht_tmp = pu2_src[(ht - 1) * src_strd];
     }
 
     /* If Left is not available */
@@ -1020,17 +1020,17 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
     /* If Top is not available */
     if(0 == pu1_avail[2])
     {
-        pu2_src += i4_src_strd;
-        i4_ht--;
+        pu2_src += src_strd;
+        ht--;
         pu2_src_left_cpy += 1;
-        for(col = 0; col < i4_wd - 1; col++)
+        for(col = 0; col < wd - 1; col++)
         {
-            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col + 1 - i4_src_strd]);
+            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col + 1 - src_strd]);
         }
     }
     else
     {
-        for(col = 0; col < i4_wd - 1; col++)
+        for(col = 0; col < wd - 1; col++)
         {
             au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src_top[col + 1]);
         }
@@ -1039,26 +1039,26 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
     /* If Right is not available */
     if(0 == pu1_avail[1])
     {
-        au1_mask[i4_wd - 1] = 0;
+        au1_mask[wd - 1] = 0;
     }
 
     /* If Bottom is not available */
     if(0 == pu1_avail[3])
     {
-        i4_ht--;
+        ht--;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
-            au1_sign_up[i4_wd - 1] = SIGN(pu2_src[i4_wd - 1] - pu2_src[i4_wd - 1 + 1 - i4_src_strd]);
-            for(col = 0; col < i4_wd; col++)
+            au1_sign_up[wd - 1] = SIGN(pu2_src[wd - 1] - pu2_src[wd - 1 + 1 - src_strd]);
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
 
                 u1_sign_down = SIGN(pu2_src[col] - ((col == 0) ? pu2_src_left_cpy[row + 1] :
-                                                            pu2_src[col - 1 + i4_src_strd]));
+                                                            pu2_src[col - 1 + src_strd]));
                 edge_idx = 2 + au1_sign_up[col] + u1_sign_down;
                 if(col > 0)
                     au1_sign_up[col - 1] = -u1_sign_down;
@@ -1071,23 +1071,23 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
                 }
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
 
-        pu2_src[- (pu1_avail[2] ? i4_ht : i4_ht + 1) * i4_src_strd + i4_wd - 1] = u2_pos_wd_0_tmp;
-        pu2_src[(pu1_avail[3] ?  (-i4_src_strd) : 0)] = u2_pos_0_ht_tmp;
+        pu2_src[- (pu1_avail[2] ? ht : ht + 1) * src_strd + wd - 1] = u2_pos_wd_0_tmp;
+        pu2_src[(pu1_avail[3] ?  (-src_strd) : 0)] = u2_pos_0_ht_tmp;
     }
 
     if(0 == pu1_avail[2])
-        i4_ht++;
+        ht++;
     if(0 == pu1_avail[3])
-        i4_ht++;
+        ht++;
     *pu2_src_top_left = u2_src_top_left_tmp;
-    for(row = 0; row < i4_ht; row++)
+    for(row = 0; row < ht; row++)
     {
         pu2_src_left[row] = au2_src_left_tmp[row];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
         pu2_src_top[col] = au2_src_top_tmp[col];
     }
@@ -1095,7 +1095,7 @@ void ihevc_hbd_sao_edge_offset_class3(UWORD16 *pu2_src,
 
 
 void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
-                                             WORD32 i4_src_strd,
+                                             WORD32 src_strd,
                                              UWORD16 *pu2_src_left,
                                              UWORD16 *pu2_src_top,
                                              UWORD16 *pu2_src_top_left,
@@ -1104,8 +1104,8 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
                                              UWORD8 *pu1_avail,
                                              WORD8 *pi1_sao_offset_u,
                                              WORD8 *pi1_sao_offset_v,
-                                             WORD32 i4_wd,
-                                             WORD32 i4_ht,
+                                             WORD32 wd,
+                                             WORD32 ht,
                                              UWORD32 u4_bit_depth)
 {
     WORD32 row, col;
@@ -1127,16 +1127,16 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
     memset(au1_mask, 0xFF, MAX_CTB_SIZE);
 
     /* Update left, top and top-left arrays */
-    au2_src_top_left_tmp[0] = pu2_src_top[i4_wd - 2];
-    au2_src_top_left_tmp[1] = pu2_src_top[i4_wd - 1];
-    for(row = 0; row < i4_ht; row++)
+    au2_src_top_left_tmp[0] = pu2_src_top[wd - 2];
+    au2_src_top_left_tmp[1] = pu2_src_top[wd - 1];
+    for(row = 0; row < ht; row++)
     {
-        au2_src_left_tmp[2 * row] = pu2_src[row * i4_src_strd + i4_wd - 2];
-        au2_src_left_tmp[2 * row + 1] = pu2_src[row * i4_src_strd + i4_wd - 1];
+        au2_src_left_tmp[2 * row] = pu2_src[row * src_strd + wd - 2];
+        au2_src_left_tmp[2 * row + 1] = pu2_src[row * src_strd + wd - 1];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
-        au2_src_top_tmp[col] = pu2_src[(i4_ht - 1) * i4_src_strd + col];
+        au2_src_top_tmp[col] = pu2_src[(ht - 1) * src_strd + col];
     }
 
     /* If top-right is available, process separately */
@@ -1145,39 +1145,39 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
         WORD32 edge_idx;
 
         /* U */
-        edge_idx = 2 + SIGN(pu2_src[i4_wd - 2] - pu2_src_top_right[0]) +
-                        SIGN(pu2_src[i4_wd - 2] - pu2_src[i4_wd - 2 - 2 + i4_src_strd]);
+        edge_idx = 2 + SIGN(pu2_src[wd - 2] - pu2_src_top_right[0]) +
+                        SIGN(pu2_src[wd - 2] - pu2_src[wd - 2 - 2 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_wd_0_tmp_u = CLIP3(pu2_src[i4_wd - 2] + pi1_sao_offset_u[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_wd_0_tmp_u = CLIP3(pu2_src[wd - 2] + pi1_sao_offset_u[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_wd_0_tmp_u = pu2_src[i4_wd - 2];
+            u2_pos_wd_0_tmp_u = pu2_src[wd - 2];
         }
 
         /* V */
-        edge_idx = 2 + SIGN(pu2_src[i4_wd - 1] - pu2_src_top_right[1]) +
-                        SIGN(pu2_src[i4_wd - 1] - pu2_src[i4_wd - 1 - 2 + i4_src_strd]);
+        edge_idx = 2 + SIGN(pu2_src[wd - 1] - pu2_src_top_right[1]) +
+                        SIGN(pu2_src[wd - 1] - pu2_src[wd - 1 - 2 + src_strd]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_wd_0_tmp_v = CLIP3(pu2_src[i4_wd - 1] + pi1_sao_offset_v[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_wd_0_tmp_v = CLIP3(pu2_src[wd - 1] + pi1_sao_offset_v[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_wd_0_tmp_v = pu2_src[i4_wd - 1];
+            u2_pos_wd_0_tmp_v = pu2_src[wd - 1];
         }
     }
     else
     {
-        u2_pos_wd_0_tmp_u = pu2_src[i4_wd - 2];
-        u2_pos_wd_0_tmp_v = pu2_src[i4_wd - 1];
+        u2_pos_wd_0_tmp_u = pu2_src[wd - 2];
+        u2_pos_wd_0_tmp_v = pu2_src[wd - 1];
     }
 
     /* If bottom-left is available, process separately */
@@ -1186,39 +1186,39 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
         WORD32 edge_idx;
 
         /* U */
-        edge_idx = 2 + SIGN(pu2_src[(i4_ht - 1) * i4_src_strd] - pu2_src[(i4_ht - 1) * i4_src_strd + 2 - i4_src_strd]) +
-                        SIGN(pu2_src[(i4_ht - 1) * i4_src_strd] - pu2_src_bot_left[0]);
+        edge_idx = 2 + SIGN(pu2_src[(ht - 1) * src_strd] - pu2_src[(ht - 1) * src_strd + 2 - src_strd]) +
+                        SIGN(pu2_src[(ht - 1) * src_strd] - pu2_src_bot_left[0]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_0_ht_tmp_u = CLIP3(pu2_src[(i4_ht - 1) * i4_src_strd] + pi1_sao_offset_u[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_0_ht_tmp_u = CLIP3(pu2_src[(ht - 1) * src_strd] + pi1_sao_offset_u[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_0_ht_tmp_u = pu2_src[(i4_ht - 1) * i4_src_strd];
+            u2_pos_0_ht_tmp_u = pu2_src[(ht - 1) * src_strd];
         }
 
         /* V */
-        edge_idx = 2 + SIGN(pu2_src[(i4_ht - 1) * i4_src_strd + 1] - pu2_src[(i4_ht - 1) * i4_src_strd + 1 + 2 - i4_src_strd]) +
-                        SIGN(pu2_src[(i4_ht - 1) * i4_src_strd + 1] - pu2_src_bot_left[1]);
+        edge_idx = 2 + SIGN(pu2_src[(ht - 1) * src_strd + 1] - pu2_src[(ht - 1) * src_strd + 1 + 2 - src_strd]) +
+                        SIGN(pu2_src[(ht - 1) * src_strd + 1] - pu2_src_bot_left[1]);
 
         edge_idx = gi4_ihevc_hbd_table_edge_idx[edge_idx];
 
         if(0 != edge_idx)
         {
-            u2_pos_0_ht_tmp_v = CLIP3(pu2_src[(i4_ht - 1) * i4_src_strd + 1] + pi1_sao_offset_v[edge_idx], 0, (1 << u4_bit_depth) - 1);
+            u2_pos_0_ht_tmp_v = CLIP3(pu2_src[(ht - 1) * src_strd + 1] + pi1_sao_offset_v[edge_idx], 0, (1 << u4_bit_depth) - 1);
         }
         else
         {
-            u2_pos_0_ht_tmp_v = pu2_src[(i4_ht - 1) * i4_src_strd + 1];
+            u2_pos_0_ht_tmp_v = pu2_src[(ht - 1) * src_strd + 1];
         }
     }
     else
     {
-        u2_pos_0_ht_tmp_u = pu2_src[(i4_ht - 1) * i4_src_strd];
-        u2_pos_0_ht_tmp_v = pu2_src[(i4_ht - 1) * i4_src_strd + 1];
+        u2_pos_0_ht_tmp_u = pu2_src[(ht - 1) * src_strd];
+        u2_pos_0_ht_tmp_v = pu2_src[(ht - 1) * src_strd + 1];
     }
 
     /* If Left is not available */
@@ -1230,17 +1230,17 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
     /* If Top is not available */
     if(0 == pu1_avail[2])
     {
-        pu2_src += i4_src_strd;
-        i4_ht--;
+        pu2_src += src_strd;
+        ht--;
         pu2_src_left_cpy += 2;
-        for(col = 0; col < i4_wd - 2; col++)
+        for(col = 0; col < wd - 2; col++)
         {
-            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col + 2 - i4_src_strd]);
+            au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src[col + 2 - src_strd]);
         }
     }
     else
     {
-        for(col = 0; col < i4_wd - 2; col++)
+        for(col = 0; col < wd - 2; col++)
         {
             au1_sign_up[col] = SIGN(pu2_src[col] - pu2_src_top[col + 2]);
         }
@@ -1249,22 +1249,22 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
     /* If Right is not available */
     if(0 == pu1_avail[1])
     {
-        au1_mask[(i4_wd - 1) >> 1] = 0;
+        au1_mask[(wd - 1) >> 1] = 0;
     }
 
     /* If Bottom is not available */
     if(0 == pu1_avail[3])
     {
-        i4_ht--;
+        ht--;
     }
 
     /* Processing is done on the intermediate buffer and the output is written to the source buffer */
     {
-        for(row = 0; row < i4_ht; row++)
+        for(row = 0; row < ht; row++)
         {
-            au1_sign_up[i4_wd - 2] = SIGN(pu2_src[i4_wd - 2] - pu2_src[i4_wd - 2 + 2 - i4_src_strd]);
-            au1_sign_up[i4_wd - 1] = SIGN(pu2_src[i4_wd - 1] - pu2_src[i4_wd - 1 + 2 - i4_src_strd]);
-            for(col = 0; col < i4_wd; col++)
+            au1_sign_up[wd - 2] = SIGN(pu2_src[wd - 2] - pu2_src[wd - 2 + 2 - src_strd]);
+            au1_sign_up[wd - 1] = SIGN(pu2_src[wd - 1] - pu2_src[wd - 1 + 2 - src_strd]);
+            for(col = 0; col < wd; col++)
             {
                 WORD32 edge_idx;
                 WORD8 *pi1_sao_offset;
@@ -1272,7 +1272,7 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
                 pi1_sao_offset = (0 == col % 2) ? pi1_sao_offset_u : pi1_sao_offset_v;
 
                 u1_sign_down = SIGN(pu2_src[col] - ((col < 2) ? pu2_src_left_cpy[2 * (row + 1) + col] :
-                                                                    pu2_src[col - 2 + i4_src_strd]));
+                                                                    pu2_src[col - 2 + src_strd]));
                 edge_idx = 2 + au1_sign_up[col] + u1_sign_down;
                 if(col > 1)
                     au1_sign_up[col - 2] = -u1_sign_down;
@@ -1285,26 +1285,26 @@ void ihevc_hbd_sao_edge_offset_class3_chroma(UWORD16 *pu2_src,
                 }
             }
 
-            pu2_src += i4_src_strd;
+            pu2_src += src_strd;
         }
 
-        pu2_src[- (pu1_avail[2] ? i4_ht : i4_ht + 1) * i4_src_strd + i4_wd - 2] = u2_pos_wd_0_tmp_u;
-        pu2_src[- (pu1_avail[2] ? i4_ht : i4_ht + 1) * i4_src_strd + i4_wd - 1] = u2_pos_wd_0_tmp_v;
-        pu2_src[(pu1_avail[3] ?  (-i4_src_strd) : 0)] = u2_pos_0_ht_tmp_u;
-        pu2_src[(pu1_avail[3] ?  (-i4_src_strd) : 0) + 1] = u2_pos_0_ht_tmp_v;
+        pu2_src[- (pu1_avail[2] ? ht : ht + 1) * src_strd + wd - 2] = u2_pos_wd_0_tmp_u;
+        pu2_src[- (pu1_avail[2] ? ht : ht + 1) * src_strd + wd - 1] = u2_pos_wd_0_tmp_v;
+        pu2_src[(pu1_avail[3] ?  (-src_strd) : 0)] = u2_pos_0_ht_tmp_u;
+        pu2_src[(pu1_avail[3] ?  (-src_strd) : 0) + 1] = u2_pos_0_ht_tmp_v;
     }
 
     if(0 == pu1_avail[2])
-        i4_ht++;
+        ht++;
     if(0 == pu1_avail[3])
-        i4_ht++;
+        ht++;
     pu2_src_top_left[0] = au2_src_top_left_tmp[0];
     pu2_src_top_left[1] = au2_src_top_left_tmp[1];
-    for(row = 0; row < 2 * i4_ht; row++)
+    for(row = 0; row < 2 * ht; row++)
     {
         pu2_src_left[row] = au2_src_left_tmp[row];
     }
-    for(col = 0; col < i4_wd; col++)
+    for(col = 0; col < wd; col++)
     {
         pu2_src_top[col] = au2_src_top_tmp[col];
     }

--- a/common/ihevc_hbd_tables_x86_intr.h
+++ b/common/ihevc_hbd_tables_x86_intr.h
@@ -24,7 +24,7 @@
 *  Declarations for the fucntions defined in  ihevc_intra_pred_filters
 *
 * @author
-*  Mamatha
+*  Ittiam
 *
 *
 * @remarks
@@ -37,13 +37,13 @@
 #define IHEVC_HBD_TABLES_X86_INTR_H_
 
 
-//Luma intra pred
+// Luma intra pred
 extern const UWORD8 IHEVCE_SHUFFLEMASKY1_HBD[16];
 extern const UWORD8 IHEVCE_SHUFFLEMASKY2_HBD[16] ;
 extern const UWORD8 IHEVCE_SHUFFLEMASKY3_HBD[16] ;
 extern const UWORD8 IHEVCE_SHUFFLEMASK4_HBD[16] ;
 extern const UWORD8 IHEVCE_SHUFFLEMASK5_HBD[16] ;
-//Chroma intra pred
+// Chroma intra pred
 extern const UWORD8 IHEVCE_SHUFFLEMASKY7_HBD[16] ;
 
 extern const UWORD8 IHEVCE_SHUFFLEMASKY8_HBD[16] ;
@@ -67,7 +67,7 @@ extern const WORD16 delta1_hbd[8];
 extern const WORD32 shuffle_uv_hbd[4];
 extern const WORD32 shuffle_uv_hbd1[4];
 extern const WORD32 shuffle_uv_hbd2[4];
-//SAO  TABLES
+// SAO TABLES
 extern  const WORD8 gi1_table_edge_idx_hbd[5] ;
 extern  const WORD8 gi1_table_band_idx_hbd[44];
 extern  const WORD32 gi4_ihevc_hbd_table_edge_idx[5];
@@ -76,4 +76,4 @@ extern  const WORD32 gi4_ihevc_hbd_table_edge_idx[5];
 extern const WORD16 g_ai2_ihevc_trans_16_even_hbd[12][8];
 extern const WORD16 g_ai2_ihevc_trans_16_odd_hbd[32][8];
 
-#endif /*IHEVC_TABLES_X86_INTR_H_*/
+#endif /* IHEVC_HBD_TABLES_X86_INTR_H_ */

--- a/common/ihevc_hbd_weighted_pred.c
+++ b/common/ihevc_hbd_weighted_pred.c
@@ -113,24 +113,24 @@ void ihevc_hbd_weighted_pred_uni(WORD16 *pi2_src,
                                  UWORD8 bit_depth)
 {
     WORD32 row, col;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = (pi2_src[col] + lvl_shift) * wgt0;
-            i4_tmp += 1 << (shift - 1);
-            i4_tmp = (i4_tmp >> shift) + off0;
+            tmp = (pi2_src[col] + lvl_shift) * wgt0;
+            tmp += 1 << (shift - 1);
+            tmp = (tmp >> shift) + off0;
 
-            pu2_dst[col] = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = CLIP3(tmp,0,((1<<bit_depth)-1));
         }
 
         pi2_src += src_strd;
         pu2_dst += dst_strd;
     }
 }
- //WEIGHTED_PRED_HBD_UNI
+ // WEIGHTED_PRED_HBD_UNI
 
 /**
 *******************************************************************************
@@ -199,30 +199,30 @@ void ihevc_hbd_weighted_pred_chroma_uni(WORD16 *pi2_src,
                                         UWORD8 bit_depth)
 {
     WORD32 row, col;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2 * wd; col += 2)
         {
-            i4_tmp = (pi2_src[col] + lvl_shift) * wgt0_cb;
-            i4_tmp += 1 << (shift - 1);
-            i4_tmp = (i4_tmp >> shift) + off0_cb;
+            tmp = (pi2_src[col] + lvl_shift) * wgt0_cb;
+            tmp += 1 << (shift - 1);
+            tmp = (tmp >> shift) + off0_cb;
 
-            pu2_dst[col] = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col] = CLIP3(tmp,0,((1<<bit_depth)-1));
 
-            i4_tmp = (pi2_src[col + 1] + lvl_shift) * wgt0_cr;
-            i4_tmp += 1 << (shift - 1);
-            i4_tmp = (i4_tmp >> shift) + off0_cr;
+            tmp = (pi2_src[col + 1] + lvl_shift) * wgt0_cr;
+            tmp += 1 << (shift - 1);
+            tmp = (tmp >> shift) + off0_cr;
 
-            pu2_dst[col+1] = CLIP3(i4_tmp,0,((1<<bit_depth)-1));
+            pu2_dst[col+1] = CLIP3(tmp,0,((1<<bit_depth)-1));
         }
 
         pi2_src += src_strd;
         pu2_dst += dst_strd;
     }
 }
- //WEIGHTED_PRED_HBD_CHROMA_UNI
+ // WEIGHTED_PRED_HBD_CHROMA_UNI
 
 /**
 *******************************************************************************
@@ -306,17 +306,17 @@ void ihevc_hbd_weighted_pred_bi(WORD16 *pi2_src1,
                                 UWORD8 bit_depth)
 {
     WORD32 row, col;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = (pi2_src1[col] + lvl_shift1) * wgt0;
-            i4_tmp += (pi2_src2[col] + lvl_shift2) * wgt1;
-            i4_tmp += (off0 + off1 + 1) << (shift - 1);
+            tmp = (pi2_src1[col] + lvl_shift1) * wgt0;
+            tmp += (pi2_src2[col] + lvl_shift2) * wgt1;
+            tmp += (off0 + off1 + 1) << (shift - 1);
 
-            pu2_dst[col] = CLIP3(i4_tmp >> shift,0,((1<<bit_depth)-1));
+            pu2_dst[col] = CLIP3(tmp >> shift,0,((1<<bit_depth)-1));
         }
 
         pi2_src1 += src_strd1;
@@ -324,7 +324,7 @@ void ihevc_hbd_weighted_pred_bi(WORD16 *pi2_src1,
         pu2_dst += dst_strd;
     }
 }
- //WEIGHTED_PRED_HBD_BI
+ // WEIGHTED_PRED_HBD_BI
 
 /**
 *******************************************************************************
@@ -412,23 +412,23 @@ void ihevc_hbd_weighted_pred_chroma_bi(WORD16 *pi2_src1,
                                        UWORD8 bit_depth)
 {
     WORD32 row, col;
-    WORD32 i4_tmp;
+    WORD32 tmp;
 
     for(row = 0; row < ht; row++)
     {
         for(col = 0; col < 2 * wd; col += 2)
         {
-            i4_tmp = (pi2_src1[col] + lvl_shift1) * wgt0_cb;
-            i4_tmp += (pi2_src2[col] + lvl_shift2) * wgt1_cb;
-            i4_tmp += (off0_cb + off1_cb + 1) << (shift - 1);
+            tmp = (pi2_src1[col] + lvl_shift1) * wgt0_cb;
+            tmp += (pi2_src2[col] + lvl_shift2) * wgt1_cb;
+            tmp += (off0_cb + off1_cb + 1) << (shift - 1);
 
-            pu2_dst[col] = CLIP3(i4_tmp >> shift,0,((1<<bit_depth)-1));
+            pu2_dst[col] = CLIP3(tmp >> shift,0,((1<<bit_depth)-1));
 
-            i4_tmp = (pi2_src1[col + 1] + lvl_shift1) * wgt0_cr;
-            i4_tmp += (pi2_src2[col + 1] + lvl_shift2) * wgt1_cr;
-            i4_tmp += (off0_cr + off1_cr + 1) << (shift - 1);
+            tmp = (pi2_src1[col + 1] + lvl_shift1) * wgt0_cr;
+            tmp += (pi2_src2[col + 1] + lvl_shift2) * wgt1_cr;
+            tmp += (off0_cr + off1_cr + 1) << (shift - 1);
 
-            pu2_dst[col+1] = CLIP3(i4_tmp >> shift,0,((1<<bit_depth)-1));
+            pu2_dst[col+1] = CLIP3(tmp >> shift,0,((1<<bit_depth)-1));
         }
 
         pi2_src1 += src_strd1;
@@ -436,7 +436,7 @@ void ihevc_hbd_weighted_pred_chroma_bi(WORD16 *pi2_src1,
         pu2_dst += dst_strd;
     }
 }
- //WEIGHTED_PRED_HBD_CHROMA_BI
+ // WEIGHTED_PRED_HBD_CHROMA_BI
 
 /**
 *******************************************************************************
@@ -500,7 +500,7 @@ void ihevc_hbd_weighted_pred_bi_default(WORD16 *pi2_src1,
                                         UWORD8 bit_depth)
 {
     WORD32 row, col;
-    WORD32 i4_tmp;
+    WORD32 tmp;
     WORD32 shift;
 
     shift = 14 - bit_depth + 1;
@@ -508,11 +508,11 @@ void ihevc_hbd_weighted_pred_bi_default(WORD16 *pi2_src1,
     {
         for(col = 0; col < wd; col++)
         {
-            i4_tmp = pi2_src1[col] + lvl_shift1;
-            i4_tmp += pi2_src2[col] + lvl_shift2;
-            i4_tmp += 1 << (shift - 1);
+            tmp = pi2_src1[col] + lvl_shift1;
+            tmp += pi2_src2[col] + lvl_shift2;
+            tmp += 1 << (shift - 1);
 
-            pu2_dst[col] = CLIP3(i4_tmp >> shift,0,((1<<bit_depth)-1));
+            pu2_dst[col] = CLIP3(tmp >> shift,0,((1<<bit_depth)-1));
         }
 
         pi2_src1 += src_strd1;
@@ -520,7 +520,7 @@ void ihevc_hbd_weighted_pred_bi_default(WORD16 *pi2_src1,
         pu2_dst += dst_strd;
     }
 }
- //WEIGHTED_PRED_HBD_BI_DEFAULT
+ // WEIGHTED_PRED_HBD_BI_DEFAULT
 
 /**
 *******************************************************************************
@@ -584,7 +584,7 @@ void ihevc_hbd_weighted_pred_chroma_bi_default(WORD16 *pi2_src1,
                                                UWORD8 bit_depth)
 {
     WORD32 row, col;
-    WORD32 i4_tmp;
+    WORD32 tmp;
     WORD32 shift;
 
     shift = 14 - bit_depth + 1;
@@ -592,11 +592,11 @@ void ihevc_hbd_weighted_pred_chroma_bi_default(WORD16 *pi2_src1,
     {
         for(col = 0; col < 2 * wd; col++)
         {
-            i4_tmp = pi2_src1[col] + lvl_shift1;
-            i4_tmp += pi2_src2[col] + lvl_shift2;
-            i4_tmp += 1 << (shift - 1);
+            tmp = pi2_src1[col] + lvl_shift1;
+            tmp += pi2_src2[col] + lvl_shift2;
+            tmp += 1 << (shift - 1);
 
-            pu2_dst[col] = CLIP3(i4_tmp >> shift,0,((1<<bit_depth)-1));
+            pu2_dst[col] = CLIP3(tmp >> shift,0,((1<<bit_depth)-1));
         }
 
         pi2_src1 += src_strd1;
@@ -604,4 +604,4 @@ void ihevc_hbd_weighted_pred_chroma_bi_default(WORD16 *pi2_src1,
         pu2_dst += dst_strd;
     }
 }
- //WEIGHTED_PRED_HBD_CHROMA_BI_DEFAULT
+ // WEIGHTED_PRED_HBD_CHROMA_BI_DEFAULT

--- a/common/ihevc_quant_iquant_ssd.h
+++ b/common/ihevc_quant_iquant_ssd.h
@@ -93,7 +93,7 @@ typedef WORD32 ihevc_hbd_quant_iquant_ssd_ft
     WORD32 *zero_row,
     WORD16 *pi2_dequant_coeff,
     LWORD64 *pi8_cost,
-    WORD32 i4_bit_depth
+    WORD32 bit_depth
     );
 
 

--- a/common/ihevc_sao.h
+++ b/common/ihevc_sao.h
@@ -68,7 +68,7 @@ typedef void ihevc_hbd_sao_band_offset_luma_ft(UWORD16 *pu2_src,
                                                WORD8 *pi1_sao_offset,
                                                WORD32 wd,
                                                WORD32 ht,
-                                               UWORD32 bitdepth);
+                                               UWORD32 bit_depth);
 
 typedef void ihevc_sao_band_offset_chroma_ft(UWORD8 *pu1_src,
                                              WORD32 src_strd,


### PR DESCRIPTION
Review and standardize newly added HBD files in common:
- Remove i4_ prefix from WORD32 local variables and function arguments.
- Standardize variable short forms (stride -> strd, width -> wd, height -> ht).
- Ensure comments have proper spacing after // and /* and before */.
- Update file header author attribution to Ittiam.
- Remove commented-out code blocks.
- Ensure indentation is consistent (4-space indentation, no tabs).

TAG=agy
CONV=ad142ae8-fa4a-4892-b9bf-a85483b1678b