### PR TITLE
common: Remove unnecessary ihevc_function_selector.h inclusions

### DIFF
--- a/common/ihevc_hbd_chroma_intra_pred_filters.c
+++ b/common/ihevc_hbd_chroma_intra_pred_filters.c
@@ -64,7 +64,6 @@
 
 #include "ihevc_typedefs.h"
 #include "ihevc_macros.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_platform_macros.h"
 #include "ihevc_intra_pred.h"
 #include "ihevc_defs.h"

--- a/common/ihevc_hbd_chroma_iquant_recon.c
+++ b/common/ihevc_hbd_chroma_iquant_recon.c
@@ -46,7 +46,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_chroma_iquant_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions work one component(U or V) of interleaved data depending upon pointers passed to it */

--- a/common/ihevc_hbd_chroma_itrans_recon.c
+++ b/common/ihevc_hbd_chroma_itrans_recon.c
@@ -46,7 +46,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_chroma_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions work one component(U or V) of interleaved data depending upon pointers passed to it */

--- a/common/ihevc_hbd_chroma_itrans_recon_16x16.c
+++ b/common/ihevc_hbd_chroma_itrans_recon_16x16.c
@@ -44,7 +44,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_chroma_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions work one component(U or V) of interleaved data depending upon pointers passed to it */

--- a/common/ihevc_hbd_chroma_itrans_recon_32x32.c
+++ b/common/ihevc_hbd_chroma_itrans_recon_32x32.c
@@ -43,7 +43,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_chroma_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 

--- a/common/ihevc_hbd_chroma_itrans_recon_8x8.c
+++ b/common/ihevc_hbd_chroma_itrans_recon_8x8.c
@@ -44,7 +44,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_chroma_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions work one component(U or V) of interleaved data depending upon pointers passed to it */

--- a/common/ihevc_hbd_chroma_recon.c
+++ b/common/ihevc_hbd_chroma_recon.c
@@ -45,7 +45,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_chroma_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions work one component(U or V) of interleaved data depending upon pointers passed to it */

--- a/common/ihevc_hbd_inter_pred_filters.c
+++ b/common/ihevc_hbd_inter_pred_filters.c
@@ -58,7 +58,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_macros.h"
 #include "ihevc_platform_macros.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_inter_pred.h"
 
 

--- a/common/ihevc_hbd_intra_pred_filters.c
+++ b/common/ihevc_hbd_intra_pred_filters.c
@@ -54,11 +54,9 @@
 #include "ihevc_typedefs.h"
 #include "ihevc_intra_pred.h"
 #include "ihevc_macros.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_platform_macros.h"
 #include "ihevc_common_tables.h"
 #include "ihevc_defs.h"
-#include "ihevc_intra_pred.h"
 
 /****************************************************************************/
 /* Constant Macros                                                          */

--- a/common/ihevc_hbd_iquant_recon.c
+++ b/common/ihevc_hbd_iquant_recon.c
@@ -47,7 +47,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_iquant_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions here are replicated from ihevc_iquant_itrans_recon.c and modified to */

--- a/common/ihevc_hbd_itrans_recon.c
+++ b/common/ihevc_hbd_itrans_recon.c
@@ -47,7 +47,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions here are replicated from ihevc_itrans.c and modified to */

--- a/common/ihevc_hbd_itrans_recon_16x16.c
+++ b/common/ihevc_hbd_itrans_recon_16x16.c
@@ -43,7 +43,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /**

--- a/common/ihevc_hbd_itrans_recon_32x32.c
+++ b/common/ihevc_hbd_itrans_recon_32x32.c
@@ -43,7 +43,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 

--- a/common/ihevc_hbd_itrans_recon_8x8.c
+++ b/common/ihevc_hbd_itrans_recon_8x8.c
@@ -43,7 +43,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_itrans_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /**

--- a/common/ihevc_hbd_padding.c
+++ b/common/ihevc_hbd_padding.c
@@ -38,7 +38,7 @@
 
 #include <string.h>
 #include "ihevc_typedefs.h"
-#include "ihevc_function_selector.h"
+#include "ihevc_padding.h"
 #include "ihevc_platform_macros.h"
 
 /**

--- a/common/ihevc_hbd_recon.c
+++ b/common/ihevc_hbd_recon.c
@@ -46,7 +46,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_trans_tables.h"
 #include "ihevc_recon.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_trans_macros.h"
 
 /* All the functions here are replicated from ihevc.c and modified to */

--- a/common/ihevc_hbd_sao.c
+++ b/common/ihevc_hbd_sao.c
@@ -39,7 +39,6 @@
 #include "ihevc_typedefs.h"
 #include "ihevc_macros.h"
 #include "ihevc_platform_macros.h"
-#include "ihevc_function_selector.h"
 #include "ihevc_defs.h"
 #include "ihevc_structs.h"
 #include "ihevc_sao.h"

--- a/common/ihevc_hbd_weighted_pred.c
+++ b/common/ihevc_hbd_weighted_pred.c
@@ -44,8 +44,6 @@
 #include "ihevc_defs.h"
 #include "ihevc_macros.h"
 #include "ihevc_platform_macros.h"
-#include "ihevc_function_selector.h"
-
 #include "ihevc_inter_pred.h"
 
 /**


### PR DESCRIPTION
Several source files in common/ included ihevc_function_selector.h even though they do not need function selector structures. This header is only needed by function_selector.c files.

Replace ihevc_function_selector.h with ihevc_padding.h in ihevc_hbd_padding.c, and remove the unnecessary inclusions from the other HBD source files.

Test: cmake --build build && ctest --test-dir build TAG=agy
CONV=a248410c-93f6-438e-b6d3-ede13640c2a1