### PR TITLE
tests/decoder: Do not silently ignore decoder errors in DecHelper

### DIFF
--- a/tests/decoder/DecHelper.cpp
+++ b/tests/decoder/DecHelper.cpp
@@ -318,22 +318,29 @@ bool DecHelper::decodeHeader(size_t& bytesConsumed) {
 
   bytesConsumed = decodeOp.s_ivd_video_decode_op_t.u4_num_bytes_consumed;
 
-  if (ret == IV_SUCCESS) {
-    mWidth = decodeOp.s_ivd_video_decode_op_t.u4_pic_wd;
-    mHeight = decodeOp.s_ivd_video_decode_op_t.u4_pic_ht;
-    mBitDepth = decodeOp.s_ivd_video_decode_op_t.u4_bit_depth;
-    mHeaderDecoded = true;
-
-    // Allocate the output reconstructed YUV frame buffer
-    if (!mOutputBuf.allocBuffer(mWidth, mHeight, mBitDepth, mFormat)) {
-      return false;
-    }
-
-    // Transition decoder to frame decode mode using config helper
-    return setDecoderConfig(mCodec, IVD_DECODE_FRAME, 0);
+  if (ret != IV_SUCCESS ||
+      decodeOp.s_ivd_video_decode_op_t.u4_error_code != 0 ||
+      decodeOp.s_ivd_video_decode_op_t.u4_pic_wd == 0 ||
+      decodeOp.s_ivd_video_decode_op_t.u4_pic_ht == 0) {
+    return false;
   }
 
-  return false;
+  mWidth = decodeOp.s_ivd_video_decode_op_t.u4_pic_wd;
+  mHeight = decodeOp.s_ivd_video_decode_op_t.u4_pic_ht;
+  mBitDepth = decodeOp.s_ivd_video_decode_op_t.u4_bit_depth;
+
+  // Allocate the output reconstructed YUV frame buffer
+  if (!mOutputBuf.allocBuffer(mWidth, mHeight, mBitDepth, mFormat)) {
+    return false;
+  }
+
+  // Transition decoder to frame decode mode using config helper
+  if (!setDecoderConfig(mCodec, IVD_DECODE_FRAME, 0)) {
+    return false;
+  }
+
+  mHeaderDecoded = true;
+  return true;
 }
 
 bool DecHelper::decodeFrame(size_t& bytesConsumed, bool& frameReady,
@@ -411,7 +418,7 @@ bool DecHelper::flushDecoder(size_t& frameIndex) {
 
     IV_API_CALL_STATUS_T ret = ihevcd_cxa_api_function(
         static_cast<iv_obj_t*>(mCodec), &flushIp, &flushOp);
-    if (ret != IV_SUCCESS) {
+    if (ret != IV_SUCCESS || flushOp.u4_error_code != 0) {
       return false;
     }
     mInFlushMode = true;
@@ -422,6 +429,11 @@ bool DecHelper::flushDecoder(size_t& frameIndex) {
     size_t consumed = 0;
     bool frameReady = false;
     if (!decodeFrame(consumed, frameReady, frameIndex, true)) {
+      // Decoder returns an error once all the frames are flushed
+      // which is expected. So return true here.
+      return true;
+    }
+    if (!frameReady) {
       break;
     }
   }
@@ -474,18 +486,16 @@ bool DecHelper::decodeFile() {
 
     size_t consumed = 0;
     if (!mHeaderDecoded) {
-      bool header_ret = decodeHeader(consumed);
-      if (!header_ret) {
-        if (consumed == 0) {
-          return false;
-        }
-      } else {
-        inputFrameSize = mWidth * mHeight * 3;
+      if (!decodeHeader(consumed)) {
+        return false;
       }
+      inputFrameSize = mWidth * mHeight * 3;
     } else {
       bool frameReady = false;
 
-      decodeFrame(consumed, frameReady, frameIndex);
+      if (!decodeFrame(consumed, frameReady, frameIndex)) {
+        return false;
+      }
       if (consumed == 0 && !frameReady) {
         break;
       }
@@ -494,9 +504,15 @@ bool DecHelper::decodeFile() {
     mBitsFile.seek(inputFileOffset);
   }
 
+  if (!mHeaderDecoded) {
+    return false;
+  }
+
   // Flush remaining frames (invokes processDecodedFrame internally for all
   // remaining frames)
-  flushDecoder(frameIndex);
+  if (!flushDecoder(frameIndex)) {
+    return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
Do not silently ignore decoder errors during header decoding, frame decoding, and flushing:
- In decodeHeader, return false if ret != IV_SUCCESS, if u4_error_code != 0, or if picture dimensions are 0 (indicating SPS was not decoded).
- In flushDecoder, verify flush control call succeeds with u4_error_code == 0, and propagate decodeFrame errors rather than ignoring them.
- In decodeFile, check return values of decodeHeader, decodeFrame, and flushDecoder rather than ignoring failures when bytes are consumed or unconditionally returning true. Also ensure mHeaderDecoded is verified.

Test: ./hevc_dec_tests
TAG=agy
CONV=48905bde-d3a5-425e-adb8-a157966a81b1