### PR TITLE
libhevcdec: Use caller-saved registers in arm64 chroma intra pred nt_32

### DIFF
--- a/common/arm64/ihevc_intra_pred_chroma_mode_18_34.s
+++ b/common/arm64/ihevc_intra_pred_chroma_mode_18_34.s
@@ -189,19 +189,19 @@ row_kernel_32:
     ld1         {v6.8b, v7.8b}, [x0], x6
     st1         {v2.8b, v3.8b}, [x2], x3
 
-    ld1         {v8.8b, v9.8b}, [x0], x6
+    ld1         {v16.8b, v17.8b}, [x0], x6
     st1         {v4.8b, v5.8b}, [x2], x3
 
-    ld1         {v10.8b, v11.8b}, [x0], x6
+    ld1         {v18.8b, v19.8b}, [x0], x6
     st1         {v6.8b, v7.8b}, [x2], x3
 
-    ld1         {v12.8b, v13.8b}, [x0], x6
-    st1         {v8.8b, v9.8b}, [x2], x3
-    ld1         {v14.8b, v15.8b}, [x0], x6
-    st1         {v10.8b, v11.8b}, [x2], x3
+    ld1         {v20.8b, v21.8b}, [x0], x6
+    st1         {v16.8b, v17.8b}, [x2], x3
+    ld1         {v22.8b, v23.8b}, [x0], x6
+    st1         {v18.8b, v19.8b}, [x2], x3
 
-    st1         {v12.8b, v13.8b}, [x2], x3
-    st1         {v14.8b, v15.8b}, [x2], x3
+    st1         {v20.8b, v21.8b}, [x2], x3
+    st1         {v22.8b, v23.8b}, [x2], x3
 
     subs        x12, x12, #1
     bne         row_kernel_32

--- a/tests/common/ihevc_chroma_intra_pred_test.cc
+++ b/tests/common/ihevc_chroma_intra_pred_test.cc
@@ -144,7 +144,7 @@ std::string PrintChromaIntraPredTestParam(
 
 INSTANTIATE_TEST_SUITE_P(
     ChromaIntraPred, ChromaIntraPredTest,
-    ::testing::Combine(::testing::Values(4, 8, 16), ::testing::Range(0, 35),
+    ::testing::Combine(::testing::Values(4, 8, 16, 32), ::testing::Range(0, 35),
                        ::testing::Values(1, 2),  // Dst Stride Multiplier
                        ::testing::ValuesIn(getTstArch())),
     PrintChromaIntraPredTestParam);


### PR DESCRIPTION
In common/arm64/ihevc_intra_pred_chroma_mode_18_34.s, nt_32 used v8-v15 in row_kernel_32 without preserving d8-d15 on the stack.

Under AAPCS64 calling conventions, d8-d15 are callee-saved registers. Clobbering them corrupted caller-saved state (such as d10 in main.c, which cached e_cmd = IVD_CMD_VIDEO_DECODE), causing subsequent decode calls on 4:4:4 8-bit streams to fail with IVD_INVALID_API_CMD.

Replace the use of v8-v15 with caller-saved registers v16-v23, matching the convention used in kernel for nt < 32 in the same file.

Also update tests/common/ihevc_chroma_intra_pred_test.cc to test block size 32.

Test: ./hevcdec
Test: ./ihevc_chroma_intra_pred_test

Change-Id: I40411c04ab00d7e23842eb1d033c4923e3ec76e9