### PR TITLE
tests/decoder: Dynamically size input buffer based on frame dimensions

### DIFF
--- a/tests/decoder/DecHelper.cpp
+++ b/tests/decoder/DecHelper.cpp
@@ -334,6 +334,15 @@ bool DecHelper::decodeHeader(size_t& bytesConsumed) {
     return false;
   }
 
+  // Ensure input buffer is large enough for a frame
+  size_t requiredInputSize = std::max<size_t>(
+      mWidth * mHeight * 3 * ((mBitDepth + 7) / 8), 1024 * 1024);
+  if (mInputBuf.capacity() < requiredInputSize) {
+    if (!mInputBuf.allocBuffer(requiredInputSize)) {
+      return false;
+    }
+  }
+
   // Transition decoder to frame decode mode using config helper
   if (!setDecoderConfig(mCodec, IVD_DECODE_FRAME, 0)) {
     return false;
@@ -489,7 +498,7 @@ bool DecHelper::decodeFile() {
       if (!decodeHeader(consumed)) {
         return false;
       }
-      inputFrameSize = mWidth * mHeight * 3;
+      inputFrameSize = mInputBuf.capacity();
     } else {
       bool frameReady = false;
 


### PR DESCRIPTION
In DecHelper::initDecoder(), mInputBuf was statically allocated with 1 MB (1024 * 1024 bytes). For high-resolution streams with large single-slice NAL units (such as Main_422_10_B_RExt_Sony_2 at 2560x1600, where the IDR slice NAL exceeds 1.1 MB), BitsFile::read() was capped by mInputBuf's capacity, truncating the input bitstream and resulting in incomplete decoding of the frame.

- In DecHelper::decodeHeader(), dynamically reallocate mInputBuf once mWidth, mHeight, and mBitDepth are known if the required size exceeds the current buffer capacity.
- In DecHelper::decodeFile(), update inputFrameSize to mInputBuf.capacity() instead of mWidth * mHeight * 3 (which didn't account for bit depths > 8).

Test: ./hevc_dec_tests
TAG=agy
CONV=476d1054-10ff-4f19-88d5-a1c8dae7b57f