### PR TITLE
libhevcdec: Reset PPS scratch buffer and extension flags before parsing

### DIFF
--- a/decoder/ihevcd_parse_headers.c
+++ b/decoder/ihevcd_parse_headers.c
@@ -2024,6 +2024,14 @@ IHEVCD_ERROR_T ihevcd_parse_sps(codec_t *ps_codec)
         BITS_PARSE("sps_extension_4bits", value, ps_bitstrm, 4);
         ps_sps->i1_sps_extension_4bits = value;
     }
+    else
+    {
+        ps_sps->i1_sps_range_extension_flag = 0;
+        ps_sps->i1_sps_multilayer_extension_flag = 0;
+        ps_sps->i1_sps_3d_extension_flag = 0;
+        ps_sps->i1_sps_scc_extension_flag = 0;
+        ps_sps->i1_sps_extension_4bits = 0;
+    }
 
 #ifdef ENABLE_MAIN_REXT_PROFILE
     if(ps_sps->i1_sps_range_extension_flag)
@@ -2379,6 +2387,14 @@ IHEVCD_ERROR_T ihevcd_parse_pps(codec_t *ps_codec)
 
 
     ps_pps = (ps_codec->s_parse.ps_pps_base + MAX_PPS_CNT - 1);
+    /* Reset PPS to zero */
+    {
+        WORD16 *pi2_scaling_mat = ps_pps->pi2_scaling_mat;
+        tile_t *ps_tile = ps_pps->ps_tile;
+        memset(ps_pps, 0, sizeof(pps_t));
+        ps_pps->pi2_scaling_mat = pi2_scaling_mat;
+        ps_pps->ps_tile = ps_tile;
+    }
 
     ps_pps->i1_pps_id = pps_id;
 
@@ -2740,6 +2756,14 @@ IHEVCD_ERROR_T ihevcd_parse_pps(codec_t *ps_codec)
 
         BITS_PARSE("pps_extension_4bits", value, ps_bitstrm, 4);
         ps_pps->i1_pps_extension_4bits = value;
+    }
+    else
+    {
+        ps_pps->i1_pps_range_extension_flag = 0;
+        ps_pps->i1_pps_multilayer_extension_flag = 0;
+        ps_pps->i1_pps_3d_extension_flag = 0;
+        ps_pps->i1_pps_scc_extension_flag = 0;
+        ps_pps->i1_pps_extension_4bits = 0;
     }
 
 #ifdef ENABLE_MAIN_REXT_PROFILE


### PR DESCRIPTION
When parsing PPS in ihevcd_parse_pps(), the scratch buffer ps_codec->s_parse.ps_pps_base + MAX_PPS_CNT - 1 was not reset to zero, unlike ihevcd_parse_sps(). In streams with concatenated sequences where an earlier sequence set pps_extension_present_flag and range extension flags, subsequent sequences without PPS extensions would retain the stale flags. This caused the parser to attempt reading non-existent range extension syntax, leading to bitstream parsing failure.

- In ihevcd_parse_pps(), reset the scratch PPS structure to zero upon entry while preserving pi2_scaling_mat and ps_tile pointers.
- In both ihevcd_parse_pps() and ihevcd_parse_sps(), explicitly zero all extension flags when pps_extension_present_flag / sps_extension_present_flag is 0.

Test: ./hevc_dec_tests
TAG=agy
CONV=476d1054-10ff-4f19-88d5-a1c8dae7b57f